### PR TITLE
Issue #11: 最終ExecPlanサマリを追加

### DIFF
--- a/docs/execplans/2026-02-22_final-summary.md
+++ b/docs/execplans/2026-02-22_final-summary.md
@@ -1,0 +1,30 @@
+# ExecPlan Final Summary: 2026-02-22 TalkCapital 完成化対応
+
+## 対応サマリ
+- 既存Issue対応
+  - #1 Excalidraw公式レンダラー移行: 対応完了（PR #8 merge）
+  - #2 OpenRouter対応: 対応完了（PR #9 merge）
+  - #3 進捗表示UX改善: 対応済みでクローズ済みを確認
+- 自律追加Issue対応
+  - #5 CIにbuild追加: 対応完了（PR #7 merge）
+  - #6 異常系テスト拡充: 対応完了（PR #10 merge）
+
+## 主要変更点
+- CI: `install -> build -> lint -> test` を必須化
+- Export: 独自Canvas2D描画を廃止し、Excalidraw公式 `exportToBlob` に移行
+- LLM: `LLM_PROVIDER=bedrock|openrouter` で構造化処理を切替可能化
+- テスト: 異常系（OpenRouter HTTP失敗、transcribe結果取得失敗、タイムアウト、export失敗時close）を追加
+
+## 検証方法
+- ローカル検証: `npm run build && npm run lint && npm run test`
+- CI検証: PR #7, #8, #9, #10 の GitHub Actions `lint-and-test` が green
+
+## 既知の制約
+- OpenRouter/AWS の実環境E2Eは未実施（ユニットはモックベース）
+- `entire` は存在するが `entire checkpoint` サブコマンド未提供のため、Gitコミットをチェックポイントとして運用
+- ローカル元ワークツリーに未コミット変更（`PROMPT.txt`）があったため、`/tmp` クローンで作業した
+
+## フォローアップ候補
+1. 実AWS/OpenRouterを用いたE2Eスモークテストを定期実行化
+2. `--verbose` の詳細ログ（所要時間/デバッグ情報）を実装しUXを強化
+3. OpenRouter利用時の`HTTP-Referer`/`X-Title`付与やレート制限時バックオフを追加


### PR DESCRIPTION
## 概要
全Issue対応後の最終サマリを ExecPlan として追加しました。

## 追加内容
- `docs/execplans/2026-02-22_final-summary.md`
  - 対応Issue一覧（既存/自律追加）
  - 主要変更点
  - 検証方法
  - 既知の制約
  - フォローアップ候補

## 検証
- `npm run build`
- `npm run lint`
- `npm run test`

Fixes #11
