### PR TITLE
Phase 1: ストリーミングモード型定義

### DIFF
--- a/src/types/structured-content.ts
+++ b/src/types/structured-content.ts
@@ -42,6 +42,47 @@ export const structuredContentSchema = z.object({
 
 export type StructuredContent = z.infer<typeof structuredContentSchema>;
 
+// ストリーミング中間スキーマ（途中テキスト前提で制約を緩和）
+export const interimStructuredContentSchema = z.object({
+  title: z.string().min(1).max(30),
+  mainMessage: mediumText,
+  blocks: z
+    .array(
+      z.object({
+        heading: shortText,
+        bullets: z
+          .array(
+            z.object({
+              text: shortText,
+            }),
+          )
+          .min(1)
+          .max(3),
+      }),
+    )
+    .min(1)
+    .max(4),
+  speechBubbles: z
+    .array(
+      z.object({
+        quote: shortText,
+        emphasis: z.enum(['important', 'surprising', 'humorous', 'inspiring']).optional(),
+      }),
+    )
+    .min(0)
+    .max(4),
+  actions: z
+    .array(
+      z.object({
+        text: shortText,
+      }),
+    )
+    .min(0)
+    .max(3),
+});
+
+export type InterimStructuredContent = z.infer<typeof interimStructuredContentSchema>;
+
 export function getStructuredContentJsonSchema(): Record<string, unknown> {
   return {
     type: 'object',

--- a/src/types/ws-messages.ts
+++ b/src/types/ws-messages.ts
@@ -1,0 +1,41 @@
+// クライアント → サーバー
+export interface WsSessionStart {
+  type: 'session_start';
+}
+export interface WsSessionEnd {
+  type: 'session_end';
+}
+export type WsClientMessage = WsSessionStart | WsSessionEnd;
+
+// サーバー → クライアント
+export interface WsTranscriptPartial {
+  type: 'transcript_partial';
+  text: string;
+}
+export interface WsTranscriptFinal {
+  type: 'transcript_final';
+  text: string;
+}
+export interface WsGraphicUpdate {
+  type: 'graphic_update';
+  png: string; // base64
+}
+export interface WsGraphicFinal {
+  type: 'graphic_final';
+  png: string; // base64
+}
+export interface WsStatus {
+  type: 'status';
+  message: string;
+}
+export interface WsError {
+  type: 'error';
+  message: string;
+}
+export type WsServerMessage =
+  | WsTranscriptPartial
+  | WsTranscriptFinal
+  | WsGraphicUpdate
+  | WsGraphicFinal
+  | WsStatus
+  | WsError;


### PR DESCRIPTION
## Summary
- `interimStructuredContentSchema` を追加（blocks min(1), speechBubbles min(0), actions min(0).max(3)）
- `src/types/ws-messages.ts` 新規作成（WebSocketメッセージ型定義）
- 既存の `structuredContentSchema` は変更なし
- 既存23テスト全パス

Closes #14