### PR TITLE
Phase 2: Transcribe Streaming ラッパー

### DIFF
--- a/src/streaming/transcribe-stream.ts
+++ b/src/streaming/transcribe-stream.ts
@@ -1,0 +1,148 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import {
+  TranscribeStreamingClient,
+  StartStreamTranscriptionCommand,
+  type AudioStream,
+  type TranscriptResultStream,
+} from '@aws-sdk/client-transcribe-streaming';
+
+export interface TranscribeStreamEvents {
+  partial: [text: string];
+  final: [text: string];
+  error: [error: Error];
+  close: [];
+}
+
+export interface TranscribeStreamDeps {
+  client?: TranscribeStreamingClient;
+}
+
+const SILENCE_INTERVAL_MS = 10_000;
+const SAMPLE_RATE = 16_000;
+// 100ms of silence (16kHz, 16-bit mono = 3200 bytes)
+const SILENCE_CHUNK = new Uint8Array(SAMPLE_RATE * 2 * 0.1);
+
+export class TranscribeStream extends EventEmitter<TranscribeStreamEvents> {
+  private audioPassThrough: PassThrough;
+  private client: TranscribeStreamingClient;
+  private silenceTimer: ReturnType<typeof setInterval> | null = null;
+  private closed = false;
+
+  constructor(region: string, deps?: TranscribeStreamDeps) {
+    super();
+    this.audioPassThrough = new PassThrough();
+    this.client =
+      deps?.client ?? new TranscribeStreamingClient({ region });
+  }
+
+  async start(): Promise<void> {
+    const audioStream = this.createAudioStream();
+
+    const command = new StartStreamTranscriptionCommand({
+      LanguageCode: 'ja-JP',
+      MediaSampleRateHertz: SAMPLE_RATE,
+      MediaEncoding: 'pcm',
+      AudioStream: audioStream,
+    });
+
+    try {
+      const response = await this.client.send(command);
+      this.startSilenceTimer();
+      this.consumeResultStream(response.TranscriptResultStream);
+    } catch (err) {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  feedAudio(chunk: Buffer | Uint8Array): void {
+    if (this.closed) return;
+    this.audioPassThrough.write(chunk);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.stopSilenceTimer();
+    this.audioPassThrough.end();
+  }
+
+  private async *createAudioStream(): AsyncIterable<AudioStream> {
+    for await (const chunk of this.audioPassThrough) {
+      yield { AudioEvent: { AudioChunk: chunk as Uint8Array } };
+    }
+  }
+
+  private async consumeResultStream(
+    stream: AsyncIterable<TranscriptResultStream> | undefined,
+  ): Promise<void> {
+    if (!stream) {
+      this.emit('error', new Error('TranscriptResultStream is undefined'));
+      return;
+    }
+
+    try {
+      for await (const event of stream) {
+        if (event.TranscriptEvent) {
+          const results = event.TranscriptEvent.Transcript?.Results ?? [];
+          for (const result of results) {
+            const transcript =
+              result.Alternatives?.[0]?.Transcript ?? '';
+            if (!transcript) continue;
+
+            if (result.IsPartial) {
+              this.emit('partial', transcript);
+            } else {
+              this.emit('final', transcript);
+            }
+          }
+        } else if (event.BadRequestException) {
+          this.emit(
+            'error',
+            new Error(`BadRequest: ${event.BadRequestException.Message}`),
+          );
+        } else if (event.LimitExceededException) {
+          this.emit(
+            'error',
+            new Error(
+              `LimitExceeded: ${event.LimitExceededException.Message}`,
+            ),
+          );
+        } else if (event.InternalFailureException) {
+          this.emit(
+            'error',
+            new Error(
+              `InternalFailure: ${event.InternalFailureException.Message}`,
+            ),
+          );
+        } else if (event.ServiceUnavailableException) {
+          this.emit(
+            'error',
+            new Error(
+              `ServiceUnavailable: ${event.ServiceUnavailableException.Message}`,
+            ),
+          );
+        }
+      }
+    } catch (err) {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      this.emit('close');
+    }
+  }
+
+  private startSilenceTimer(): void {
+    this.silenceTimer = setInterval(() => {
+      if (!this.closed) {
+        this.audioPassThrough.write(SILENCE_CHUNK);
+      }
+    }, SILENCE_INTERVAL_MS);
+  }
+
+  private stopSilenceTimer(): void {
+    if (this.silenceTimer) {
+      clearInterval(this.silenceTimer);
+      this.silenceTimer = null;
+    }
+  }
+}

--- a/test/streaming/transcribe-stream.test.ts
+++ b/test/streaming/transcribe-stream.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TranscribeStream } from '../../src/streaming/transcribe-stream.js';
+
+function createMockClient(resultStream: AsyncIterable<any>) {
+  return {
+    send: vi.fn().mockResolvedValue({
+      TranscriptResultStream: resultStream,
+    }),
+    destroy: vi.fn(),
+    config: {},
+    middlewareStack: { add: vi.fn(), clone: vi.fn() },
+  } as any;
+}
+
+async function* makeResultStream(events: any[]): AsyncIterable<any> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+describe('TranscribeStream', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('partial result を emit する', async () => {
+    const events = [
+      {
+        TranscriptEvent: {
+          Transcript: {
+            Results: [
+              {
+                IsPartial: true,
+                Alternatives: [{ Transcript: '心理的' }],
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const client = createMockClient(makeResultStream(events));
+    const stream = new TranscribeStream('ap-northeast-1', { client });
+
+    const partials: string[] = [];
+    stream.on('partial', (text) => partials.push(text));
+
+    const closePromise = new Promise<void>((resolve) =>
+      stream.on('close', resolve),
+    );
+
+    await stream.start();
+    stream.close();
+    await closePromise;
+
+    expect(partials).toEqual(['心理的']);
+  });
+
+  it('final result を emit する', async () => {
+    const events = [
+      {
+        TranscriptEvent: {
+          Transcript: {
+            Results: [
+              {
+                IsPartial: false,
+                Alternatives: [{ Transcript: '心理的安全性とは' }],
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const client = createMockClient(makeResultStream(events));
+    const stream = new TranscribeStream('ap-northeast-1', { client });
+
+    const finals: string[] = [];
+    stream.on('final', (text) => finals.push(text));
+
+    const closePromise = new Promise<void>((resolve) =>
+      stream.on('close', resolve),
+    );
+
+    await stream.start();
+    stream.close();
+    await closePromise;
+
+    expect(finals).toEqual(['心理的安全性とは']);
+  });
+
+  it('feedAudio でPCMチャンクを送信できる', async () => {
+    const events: any[] = [];
+    const client = createMockClient(makeResultStream(events));
+    const stream = new TranscribeStream('ap-northeast-1', { client });
+
+    const closePromise = new Promise<void>((resolve) =>
+      stream.on('close', resolve),
+    );
+
+    await stream.start();
+
+    // feedAudio はエラーなく呼べる
+    const chunk = Buffer.alloc(3200); // 100ms of 16kHz 16-bit mono
+    stream.feedAudio(chunk);
+    stream.close();
+    await closePromise;
+
+    expect(client.send).toHaveBeenCalledOnce();
+  });
+
+  it('ストリームエラー時に error を emit する', async () => {
+    const events = [
+      {
+        BadRequestException: {
+          Message: 'Invalid audio format',
+        },
+      },
+    ];
+
+    const client = createMockClient(makeResultStream(events));
+    const stream = new TranscribeStream('ap-northeast-1', { client });
+
+    const errors: Error[] = [];
+    stream.on('error', (err) => errors.push(err));
+
+    const closePromise = new Promise<void>((resolve) =>
+      stream.on('close', resolve),
+    );
+
+    await stream.start();
+    stream.close();
+    await closePromise;
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('BadRequest');
+  });
+
+  it('close 後に feedAudio しても書き込まれない', async () => {
+    const events: any[] = [];
+    const client = createMockClient(makeResultStream(events));
+    const stream = new TranscribeStream('ap-northeast-1', { client });
+
+    const closePromise = new Promise<void>((resolve) =>
+      stream.on('close', resolve),
+    );
+
+    await stream.start();
+    stream.close();
+    await closePromise;
+
+    // close 後の feedAudio はエラーにならない（無視される）
+    expect(() => stream.feedAudio(Buffer.alloc(100))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- `TranscribeStream` クラスを追加（EventEmitter ベース）
- PCMチャンクを PassThrough 経由で Amazon Transcribe Streaming に供給
- partial/final results をイベントで通知
- 10秒間隔の無音チャンク送信で15秒タイムアウトを防止
- モックテスト5件追加（全28テストパス）

Closes #15