### PR TITLE
Phase 3: PlaywrightPool

### DIFF
--- a/src/streaming/playwright-pool.ts
+++ b/src/streaming/playwright-pool.ts
@@ -1,0 +1,88 @@
+import { resolve } from 'node:path';
+import { chromium, type Browser, type Page } from 'playwright';
+import type { ExcalidrawDocument } from '../types/excalidraw.js';
+
+const MAX_RENDERS_BEFORE_REFRESH = 50;
+
+export interface PlaywrightPoolDeps {
+  launchBrowser?: () => Promise<Browser>;
+}
+
+export class PlaywrightPool {
+  private browser: Browser | null = null;
+  private page: Page | null = null;
+  private renderCount = 0;
+  private busy = false;
+  private launchBrowser: () => Promise<Browser>;
+
+  constructor(deps?: PlaywrightPoolDeps) {
+    this.launchBrowser =
+      deps?.launchBrowser ?? (() => chromium.launch({ headless: true }));
+  }
+
+  async init(): Promise<void> {
+    this.browser = await this.launchBrowser();
+    await this.preparePage();
+  }
+
+  async exportToPng(
+    doc: ExcalidrawDocument,
+    scale = 2,
+  ): Promise<string> {
+    if (!this.browser || !this.page) {
+      throw new Error('PlaywrightPool is not initialized. Call init() first.');
+    }
+    if (this.busy) {
+      throw new Error('PlaywrightPool is busy. Concurrent rendering is not allowed.');
+    }
+
+    this.busy = true;
+    try {
+      const base64: string = await this.page.evaluate(
+        async ({ doc: d, renderScale }) => {
+          const fn = (window as any).renderAndExport;
+          if (typeof fn !== 'function') {
+            throw new Error('renderAndExport が見つかりません');
+          }
+          return fn(d, renderScale);
+        },
+        { doc, renderScale: scale },
+      );
+
+      this.renderCount++;
+      if (this.renderCount >= MAX_RENDERS_BEFORE_REFRESH) {
+        await this.refreshPage();
+      }
+
+      return base64;
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  async destroy(): Promise<void> {
+    if (this.page) {
+      await this.page.close().catch(() => {});
+      this.page = null;
+    }
+    if (this.browser) {
+      await this.browser.close().catch(() => {});
+      this.browser = null;
+    }
+  }
+
+  private async preparePage(): Promise<void> {
+    if (!this.browser) return;
+    this.page = await this.browser.newPage();
+    const htmlPath = resolve(process.cwd(), 'export/index.html');
+    await this.page.goto(`file://${htmlPath}`);
+    this.renderCount = 0;
+  }
+
+  private async refreshPage(): Promise<void> {
+    if (this.page) {
+      await this.page.close().catch(() => {});
+    }
+    await this.preparePage();
+  }
+}

--- a/test/streaming/playwright-pool.test.ts
+++ b/test/streaming/playwright-pool.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PlaywrightPool } from '../../src/streaming/playwright-pool.js';
+
+function createMockBrowser() {
+  const mockPage = {
+    goto: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue('base64pngdata'),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockBrowser = {
+    newPage: vi.fn().mockResolvedValue(mockPage),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  return { mockBrowser, mockPage };
+}
+
+describe('PlaywrightPool', () => {
+  it('init でブラウザとページを起動する', async () => {
+    const { mockBrowser } = createMockBrowser();
+    const pool = new PlaywrightPool({
+      launchBrowser: vi.fn().mockResolvedValue(mockBrowser),
+    });
+
+    await pool.init();
+
+    expect(mockBrowser.newPage).toHaveBeenCalledOnce();
+    await pool.destroy();
+  });
+
+  it('exportToPng で base64 PNG を返す', async () => {
+    const { mockBrowser, mockPage } = createMockBrowser();
+    mockPage.evaluate.mockResolvedValue('iVBORw0KGgo=');
+
+    const pool = new PlaywrightPool({
+      launchBrowser: vi.fn().mockResolvedValue(mockBrowser),
+    });
+    await pool.init();
+
+    const doc = {
+      type: 'excalidraw' as const,
+      version: 2 as const,
+      source: 'test',
+      elements: [],
+      appState: { viewBackgroundColor: '#fff', width: 1920, height: 1080 },
+    };
+
+    const result = await pool.exportToPng(doc);
+    expect(result).toBe('iVBORw0KGgo=');
+    expect(mockPage.evaluate).toHaveBeenCalledOnce();
+
+    await pool.destroy();
+  });
+
+  it('init 前に exportToPng を呼ぶとエラー', async () => {
+    const pool = new PlaywrightPool();
+    const doc = {
+      type: 'excalidraw' as const,
+      version: 2 as const,
+      source: 'test',
+      elements: [],
+      appState: { viewBackgroundColor: '#fff', width: 1920, height: 1080 },
+    };
+
+    await expect(pool.exportToPng(doc)).rejects.toThrow('not initialized');
+  });
+
+  it('50回レンダリング後にページが再作成される', async () => {
+    const { mockBrowser, mockPage } = createMockBrowser();
+    const pool = new PlaywrightPool({
+      launchBrowser: vi.fn().mockResolvedValue(mockBrowser),
+    });
+    await pool.init();
+
+    const doc = {
+      type: 'excalidraw' as const,
+      version: 2 as const,
+      source: 'test',
+      elements: [],
+      appState: { viewBackgroundColor: '#fff', width: 1920, height: 1080 },
+    };
+
+    // 50回レンダリング
+    for (let i = 0; i < 50; i++) {
+      await pool.exportToPng(doc);
+    }
+
+    // 初期の1回 + 50回目でリフレッシュの1回 = 2回
+    expect(mockBrowser.newPage).toHaveBeenCalledTimes(2);
+    // ページのclose: リフレッシュ時の1回
+    expect(mockPage.close).toHaveBeenCalledTimes(1);
+
+    await pool.destroy();
+  });
+
+  it('destroy でブラウザとページを閉じる', async () => {
+    const { mockBrowser, mockPage } = createMockBrowser();
+    const pool = new PlaywrightPool({
+      launchBrowser: vi.fn().mockResolvedValue(mockBrowser),
+    });
+    await pool.init();
+
+    await pool.destroy();
+
+    expect(mockPage.close).toHaveBeenCalled();
+    expect(mockBrowser.close).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `PlaywrightPool` クラス: ブラウザプール管理
- 起動時にChromiumを1回launch、export/index.htmlを事前ロード
- busy排他制御で同時レンダリング防止
- 50回ごとにページ再作成（メモリリーク対策）
- モックテスト5件追加（全33テストパス）

Closes #16