### PR TITLE
feat: StreamingSession 中核セッション (#17)

### DIFF
--- a/src/streaming/session.ts
+++ b/src/streaming/session.ts
@@ -1,0 +1,248 @@
+import { EventEmitter } from 'node:events';
+import type { Config } from '../config/index.js';
+import { TranscribeStream } from './transcribe-stream.js';
+import { PlaywrightPool } from './playwright-pool.js';
+import { structureTranscript, type StructuringDependencies } from '../services/structuring.js';
+import { renderToExcalidraw } from '../services/template-engine.js';
+import {
+  interimStructuredContentSchema,
+  structuredContentSchema,
+  type StructuredContent,
+  type InterimStructuredContent,
+} from '../types/structured-content.js';
+
+export interface SessionEvents {
+  transcript_partial: [text: string];
+  transcript_final: [text: string];
+  graphic_update: [png: string];
+  graphic_final: [png: string];
+  status: [message: string];
+  error: [error: Error];
+  close: [];
+}
+
+export interface SessionDeps {
+  transcribeStream?: TranscribeStream;
+  playwrightPool?: PlaywrightPool;
+  structuringDeps?: StructuringDependencies;
+}
+
+const UPDATE_CHAR_THRESHOLD = 500;
+
+const INTERIM_SYSTEM_PROMPT = `あなたは講演の内容をグラフィックレコーディング用に構造化するアシスタントです。
+これはリアルタイムストリーミング中の途中テキストです。講演はまだ続いています。
+
+# 厳守ルール
+1. 捏造禁止：テキストに含まれていない内容を絶対に追加しない
+2. 短文化：各テキストは目安40文字以内（日本語）
+3. titleは30文字以内（講演テーマを推定）
+4. mainMessageは80文字以内
+5. blocksは現時点で抽出できる分だけ（1〜4個）
+6. speechBubblesは印象的な発言があれば抽出（0〜4個、なければ空配列）
+7. actionsは具体的なものが見えていれば抽出（0〜3個、なければ空配列）
+8. 専門用語は元の表現をそのまま使用
+9. まだ途中のため、完璧を目指さず現時点の要約に集中する`;
+
+export class StreamingSession extends EventEmitter<SessionEvents> {
+  private config: Config;
+  private transcribeStream: TranscribeStream;
+  private playwrightPool: PlaywrightPool;
+  private structuringDeps: StructuringDependencies;
+
+  private accumulatedText = '';
+  private lastStructuredLength = 0;
+  private structuring = false;
+  private pendingRetrigger = false;
+
+  constructor(config: Config, deps?: SessionDeps) {
+    super();
+    this.config = config;
+    this.transcribeStream =
+      deps?.transcribeStream ?? new TranscribeStream(config.aws.region);
+    this.playwrightPool = deps?.playwrightPool ?? new PlaywrightPool();
+    this.structuringDeps = deps?.structuringDeps ?? {};
+  }
+
+  async start(): Promise<void> {
+    this.emit('status', 'セッション開始');
+
+    this.transcribeStream.on('partial', (text) => {
+      this.emit('transcript_partial', text);
+    });
+
+    this.transcribeStream.on('final', (text) => {
+      this.accumulatedText += text;
+      this.emit('transcript_final', text);
+      this.checkUpdateTrigger();
+    });
+
+    this.transcribeStream.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    await this.transcribeStream.start();
+  }
+
+  feedAudio(chunk: Buffer | Uint8Array): void {
+    this.transcribeStream.feedAudio(chunk);
+  }
+
+  async end(): Promise<void> {
+    this.emit('status', '最終版を生成中...');
+    this.transcribeStream.close();
+
+    if (!this.accumulatedText) {
+      this.emit('close');
+      return;
+    }
+
+    try {
+      // 最終版は厳格スキーマ（既存の structureTranscript）を使用
+      const structured = await structureTranscript(
+        this.accumulatedText,
+        this.config,
+        this.structuringDeps,
+      );
+      const doc = renderToExcalidraw(structured);
+      const png = await this.playwrightPool.exportToPng(doc);
+      this.emit('graphic_final', png);
+    } catch (err) {
+      this.emit(
+        'error',
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    } finally {
+      this.emit('close');
+    }
+  }
+
+  private checkUpdateTrigger(): void {
+    const newChars = this.accumulatedText.length - this.lastStructuredLength;
+    if (newChars < UPDATE_CHAR_THRESHOLD) return;
+
+    if (this.structuring) {
+      this.pendingRetrigger = true;
+      return;
+    }
+
+    this.triggerInterimUpdate();
+  }
+
+  private async triggerInterimUpdate(): Promise<void> {
+    this.structuring = true;
+    this.lastStructuredLength = this.accumulatedText.length;
+
+    try {
+      const interim = await this.structureInterim(this.accumulatedText);
+      const full = this.interimToStructured(interim);
+      const doc = renderToExcalidraw(full);
+      const png = await this.playwrightPool.exportToPng(doc);
+      this.emit('graphic_update', png);
+    } catch (err) {
+      this.emit(
+        'error',
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    } finally {
+      this.structuring = false;
+      if (this.pendingRetrigger) {
+        this.pendingRetrigger = false;
+        this.checkUpdateTrigger();
+      }
+    }
+  }
+
+  private async structureInterim(
+    text: string,
+  ): Promise<InterimStructuredContent> {
+    // Bedrockを呼び出し、interimスキーマでバリデーション
+    const config = { ...this.config };
+    const client =
+      this.structuringDeps.client ??
+      (await import('@aws-sdk/client-bedrock-runtime')).BedrockRuntimeClient;
+    const bedrockClient =
+      this.structuringDeps.client ??
+      new (client as any)({ region: config.bedrock.region });
+    const { ConverseCommand } = await import(
+      '@aws-sdk/client-bedrock-runtime'
+    );
+    const { getStructuredContentJsonSchema } = await import(
+      '../types/structured-content.js'
+    );
+
+    const command = new ConverseCommand({
+      modelId: config.bedrock.modelId,
+      system: [{ text: INTERIM_SYSTEM_PROMPT }],
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: `以下は講演の途中テキストです（リアルタイム文字起こし中）。現時点の内容を構造化してください。\n\n${text}`,
+            },
+          ],
+        },
+      ],
+      toolConfig: {
+        tools: [
+          {
+            toolSpec: {
+              name: 'structured_output',
+              description: '講演の構造化データを出力する（途中版）',
+              inputSchema: {
+                json: getStructuredContentJsonSchema() as any,
+              },
+            },
+          },
+        ],
+        toolChoice: { tool: { name: 'structured_output' } },
+      },
+    });
+
+    const response = await bedrockClient.send(command);
+    const content = (response.output?.message?.content ?? []) as any[];
+    let toolInput: unknown;
+    for (const item of content) {
+      if (item.toolUse?.input) {
+        toolInput = item.toolUse.input;
+        break;
+      }
+    }
+    if (!toolInput) {
+      throw new Error('Interim構造化: toolUse inputが見つかりません');
+    }
+
+    return interimStructuredContentSchema.parse(toolInput);
+  }
+
+  /** interimスキーマの結果を、renderToExcalidraw に渡せる完全な StructuredContent に変換する */
+  interimToStructured(interim: InterimStructuredContent): StructuredContent {
+    // blocks: 3個未満なら空ブロックで補完
+    const blocks = [...interim.blocks];
+    while (blocks.length < 3) {
+      blocks.push({ heading: '...', bullets: [{ text: '...' }] });
+    }
+
+    // speechBubbles: 1個未満なら空で補完
+    const speechBubbles = [...interim.speechBubbles];
+    if (speechBubbles.length === 0) {
+      speechBubbles.push({ quote: '...' });
+    }
+
+    // actions: 3個未満なら空で補完
+    const actions = [...interim.actions];
+    while (actions.length < 3) {
+      actions.push({ text: '...' });
+    }
+    // 3個に切り詰め
+    actions.length = 3;
+
+    return structuredContentSchema.parse({
+      title: interim.title,
+      mainMessage: interim.mainMessage,
+      blocks,
+      speechBubbles,
+      actions,
+    });
+  }
+}

--- a/test/streaming/session.test.ts
+++ b/test/streaming/session.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from 'vitest';
+import { StreamingSession } from '../../src/streaming/session.js';
+import type { Config } from '../../src/config/index.js';
+import type { InterimStructuredContent } from '../../src/types/structured-content.js';
+
+const mockConfig: Config = {
+  aws: { region: 'ap-northeast-1', s3Bucket: 'test', s3KeyPrefix: 'test' },
+  llm: { provider: 'bedrock' as const },
+  bedrock: { modelId: 'anthropic.claude-sonnet-4-20250514-v1:0', region: 'us-east-1' },
+  output: { scale: 2 },
+};
+
+function createMockTranscribeStream() {
+  const listeners: Record<string, ((...args: any[]) => void)[]> = {};
+  return {
+    on: vi.fn((event: string, cb: (...args: any[]) => void) => {
+      listeners[event] = listeners[event] ?? [];
+      listeners[event].push(cb);
+    }),
+    emit: (event: string, ...args: any[]) => {
+      (listeners[event] ?? []).forEach((cb) => cb(...args));
+    },
+    start: vi.fn().mockResolvedValue(undefined),
+    feedAudio: vi.fn(),
+    close: vi.fn(),
+    removeListener: vi.fn(),
+    addListener: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+    removeAllListeners: vi.fn(),
+    listenerCount: vi.fn(),
+    listeners: vi.fn(),
+    rawListeners: vi.fn(),
+    prependListener: vi.fn(),
+    prependOnceListener: vi.fn(),
+    eventNames: vi.fn(),
+    setMaxListeners: vi.fn(),
+    getMaxListeners: vi.fn(),
+  } as any;
+}
+
+function createMockPool() {
+  return {
+    init: vi.fn().mockResolvedValue(undefined),
+    exportToPng: vi.fn().mockResolvedValue('base64png'),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+describe('StreamingSession', () => {
+  it('start() で TranscribeStream を開始する', async () => {
+    const ts = createMockTranscribeStream();
+    const pool = createMockPool();
+
+    const session = new StreamingSession(mockConfig, {
+      transcribeStream: ts,
+      playwrightPool: pool,
+    });
+
+    const statuses: string[] = [];
+    session.on('status', (msg) => statuses.push(msg));
+
+    await session.start();
+
+    expect(ts.start).toHaveBeenCalledOnce();
+    expect(statuses).toContain('セッション開始');
+  });
+
+  it('feedAudio() でチャンクを TranscribeStream に転送する', async () => {
+    const ts = createMockTranscribeStream();
+    const pool = createMockPool();
+
+    const session = new StreamingSession(mockConfig, {
+      transcribeStream: ts,
+      playwrightPool: pool,
+    });
+
+    await session.start();
+
+    const chunk = Buffer.alloc(3200);
+    session.feedAudio(chunk);
+
+    expect(ts.feedAudio).toHaveBeenCalledWith(chunk);
+  });
+
+  it('final result で transcript_final を emit する', async () => {
+    const ts = createMockTranscribeStream();
+    const pool = createMockPool();
+
+    const session = new StreamingSession(mockConfig, {
+      transcribeStream: ts,
+      playwrightPool: pool,
+    });
+
+    const finals: string[] = [];
+    session.on('transcript_final', (text) => finals.push(text));
+
+    await session.start();
+    ts.emit('final', 'テスト文字起こし');
+
+    expect(finals).toEqual(['テスト文字起こし']);
+  });
+
+  it('end() で最終版 PNG を生成する', async () => {
+    const ts = createMockTranscribeStream();
+    const pool = createMockPool();
+
+    const mockBedrockClient = {
+      send: vi.fn().mockResolvedValue({
+        output: {
+          message: {
+            content: [
+              {
+                toolUse: {
+                  input: {
+                    title: 'テスト講演',
+                    mainMessage: 'テストメッセージです',
+                    blocks: [
+                      { heading: 'ブロック1', bullets: [{ text: '項目1' }] },
+                      { heading: 'ブロック2', bullets: [{ text: '項目2' }] },
+                      { heading: 'ブロック3', bullets: [{ text: '項目3' }] },
+                    ],
+                    speechBubbles: [{ quote: '名言', emphasis: 'important' }],
+                    actions: [
+                      { text: 'アクション1' },
+                      { text: 'アクション2' },
+                      { text: 'アクション3' },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    };
+
+    const session = new StreamingSession(mockConfig, {
+      transcribeStream: ts,
+      playwrightPool: pool,
+      structuringDeps: { client: mockBedrockClient as any },
+    });
+
+    const pngs: string[] = [];
+    session.on('graphic_final', (png) => pngs.push(png));
+
+    const closePromise = new Promise<void>((resolve) =>
+      session.on('close', resolve),
+    );
+
+    await session.start();
+    // テキストを蓄積
+    ts.emit('final', 'テスト文字起こし内容');
+    await session.end();
+    await closePromise;
+
+    expect(pngs).toHaveLength(1);
+    expect(pool.exportToPng).toHaveBeenCalled();
+  });
+
+  it('interimToStructured でプレースホルダ補完する', () => {
+    const ts = createMockTranscribeStream();
+    const pool = createMockPool();
+
+    const session = new StreamingSession(mockConfig, {
+      transcribeStream: ts,
+      playwrightPool: pool,
+    });
+
+    const interim: InterimStructuredContent = {
+      title: 'テスト',
+      mainMessage: 'テストメッセージ',
+      blocks: [{ heading: '見出し1', bullets: [{ text: '項目1' }] }],
+      speechBubbles: [],
+      actions: [],
+    };
+
+    const result = session.interimToStructured(interim);
+
+    // blocks は 3 個に補完される
+    expect(result.blocks).toHaveLength(3);
+    expect(result.blocks[1].heading).toBe('...');
+    // speechBubbles は 1 個に補完される
+    expect(result.speechBubbles).toHaveLength(1);
+    // actions は 3 個に補完される
+    expect(result.actions).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- StreamingSession クラスを追加（`src/streaming/session.ts`）
- 500文字蓄積ごとにinterim構造化 → PNG更新トリガー
- `interimToStructured()` でプレースホルダ補完
- `end()` で最終版PNG生成
- 5件のモックテスト追加

## Test plan
- [x] `npm run build` パス
- [x] `npm run lint` パス  
- [x] `npm run test` 全38テスト合格

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)