### PR TITLE
feat: Web UI 録音・文字起こし・グラレコ表示 (#19)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import prettier from 'eslint-config-prettier';
+import globals from 'globals';
 
 export default [
   {
@@ -18,6 +19,16 @@ export default [
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    files: ['public/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        AudioWorkletProcessor: 'readonly',
+        registerProcessor: 'readonly',
+      },
     },
   },
 ];

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,167 @@
+/** @type {WebSocket | null} */
+let ws = null;
+/** @type {AudioContext | null} */
+let audioCtx = null;
+/** @type {MediaStream | null} */
+let mediaStream = null;
+/** @type {AudioWorkletNode | null} */
+let workletNode = null;
+
+const btnStart = document.getElementById('btn-start');
+const btnStop = document.getElementById('btn-stop');
+const statusEl = document.getElementById('status');
+const transcriptEl = document.getElementById('transcript');
+const graphicEl = document.getElementById('graphic');
+const graphicPlaceholder = document.getElementById('graphic-placeholder');
+
+let finalText = '';
+let partialText = '';
+
+function setStatus(msg) {
+  statusEl.textContent = msg;
+}
+
+function updateTranscript() {
+  // 既存の子要素をすべて除去
+  while (transcriptEl.firstChild) {
+    transcriptEl.removeChild(transcriptEl.firstChild);
+  }
+
+  if (finalText) {
+    const finalSpan = document.createElement('span');
+    finalSpan.textContent = finalText;
+    transcriptEl.appendChild(finalSpan);
+  }
+
+  if (partialText) {
+    const partialSpan = document.createElement('span');
+    partialSpan.className = 'partial';
+    partialSpan.textContent = partialText;
+    transcriptEl.appendChild(partialSpan);
+  }
+}
+
+function showGraphic(base64) {
+  graphicEl.src = 'data:image/png;base64,' + base64;
+  graphicEl.style.display = 'block';
+  graphicPlaceholder.style.display = 'none';
+}
+
+function connectWebSocket() {
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  ws = new WebSocket(`${protocol}//${location.host}`);
+
+  ws.onopen = () => {
+    setStatus('接続済み');
+    ws.send(JSON.stringify({ type: 'session_start' }));
+  };
+
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data);
+
+    switch (msg.type) {
+      case 'transcript_partial':
+        partialText = msg.text;
+        updateTranscript();
+        break;
+      case 'transcript_final':
+        finalText += msg.text;
+        partialText = '';
+        updateTranscript();
+        break;
+      case 'graphic_update':
+        showGraphic(msg.png);
+        break;
+      case 'graphic_final':
+        showGraphic(msg.png);
+        setStatus('最終版グラレコ生成完了');
+        break;
+      case 'status':
+        setStatus(msg.message);
+        break;
+      case 'error':
+        setStatus('エラー: ' + msg.message);
+        console.error('Server error:', msg.message);
+        break;
+    }
+  };
+
+  ws.onclose = () => {
+    setStatus('切断');
+    ws = null;
+  };
+
+  ws.onerror = (err) => {
+    console.error('WebSocket error:', err);
+    setStatus('接続エラー');
+  };
+}
+
+async function startRecording() {
+  try {
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        sampleRate: 16000,
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+    });
+
+    audioCtx = new AudioContext({ sampleRate: 16000 });
+    await audioCtx.audioWorklet.addModule('audio-processor.js');
+
+    const source = audioCtx.createMediaStreamSource(mediaStream);
+    workletNode = new AudioWorkletNode(audioCtx, 'audio-processor');
+
+    workletNode.port.onmessage = (event) => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(event.data);
+      }
+    };
+
+    source.connect(workletNode);
+    workletNode.connect(audioCtx.destination);
+
+    connectWebSocket();
+
+    btnStart.disabled = true;
+    btnStop.disabled = false;
+    setStatus('録音中...');
+    finalText = '';
+    partialText = '';
+    while (transcriptEl.firstChild) {
+      transcriptEl.removeChild(transcriptEl.firstChild);
+    }
+  } catch (err) {
+    console.error('Recording start failed:', err);
+    setStatus('マイクの使用が許可されていません');
+  }
+}
+
+async function stopRecording() {
+  btnStop.disabled = true;
+  setStatus('最終版を生成中...');
+
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: 'session_end' }));
+  }
+
+  if (workletNode) {
+    workletNode.disconnect();
+    workletNode = null;
+  }
+  if (audioCtx) {
+    await audioCtx.close();
+    audioCtx = null;
+  }
+  if (mediaStream) {
+    mediaStream.getTracks().forEach((t) => t.stop());
+    mediaStream = null;
+  }
+
+  btnStart.disabled = false;
+}
+
+btnStart.addEventListener('click', startRecording);
+btnStop.addEventListener('click', stopRecording);

--- a/public/audio-processor.js
+++ b/public/audio-processor.js
@@ -1,0 +1,24 @@
+/**
+ * AudioWorklet Processor: Float32 → Int16 PCM 変換
+ * AudioContext(sampleRate:16000) で動作する前提
+ */
+class AudioProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+
+    const float32 = input[0];
+    if (!float32 || float32.length === 0) return true;
+
+    const int16 = new Int16Array(float32.length);
+    for (let i = 0; i < float32.length; i++) {
+      const s = Math.max(-1, Math.min(1, float32[i]));
+      int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+    }
+
+    this.port.postMessage(int16.buffer, [int16.buffer]);
+    return true;
+  }
+}
+
+registerProcessor('audio-processor', AudioProcessor);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TalkCapital - Streaming</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>TalkCapital Streaming</h1>
+    <span id="status">待機中</span>
+  </header>
+
+  <div class="controls">
+    <button id="btn-start">録音開始</button>
+    <button id="btn-stop" disabled>録音停止</button>
+  </div>
+
+  <div class="main-content">
+    <div class="transcript-panel">
+      <h2>文字起こし</h2>
+      <div id="transcript"></div>
+    </div>
+    <div class="graphic-panel">
+      <h2>グラフィックレコーディング</h2>
+      <img id="graphic" alt="グラレコ" style="display:none;">
+      <span id="graphic-placeholder">録音を開始するとグラレコが生成されます</span>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,130 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  background: #1a1a2e;
+  color: #fff;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+header h1 {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+#status {
+  font-size: 14px;
+  color: #aaa;
+  margin-left: auto;
+}
+
+.controls {
+  padding: 16px 24px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+button {
+  padding: 10px 24px;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+#btn-start {
+  background: #e94560;
+  color: #fff;
+}
+
+#btn-stop {
+  background: #555;
+  color: #fff;
+}
+
+.main-content {
+  flex: 1;
+  display: flex;
+  gap: 16px;
+  padding: 0 24px 24px;
+  min-height: 0;
+}
+
+.transcript-panel {
+  flex: 1;
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  overflow-y: auto;
+  max-height: calc(100vh - 160px);
+}
+
+.transcript-panel h2 {
+  font-size: 16px;
+  margin-bottom: 12px;
+  color: #666;
+}
+
+#transcript {
+  font-size: 14px;
+  line-height: 1.8;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+#transcript .partial {
+  color: #999;
+}
+
+.graphic-panel {
+  flex: 2;
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: auto;
+  max-height: calc(100vh - 160px);
+}
+
+.graphic-panel h2 {
+  font-size: 16px;
+  margin-bottom: 12px;
+  color: #666;
+  align-self: flex-start;
+}
+
+#graphic {
+  max-width: 100%;
+  border-radius: 4px;
+}
+
+#graphic-placeholder {
+  color: #bbb;
+  font-size: 14px;
+  margin-top: 40px;
+}


### PR DESCRIPTION
## Summary
- `public/index.html` — メインページ（録音ボタン・文字起こし・グラレコ表示）
- `public/app.js` — WebSocket接続、AudioWorklet管理、UI制御
- `public/audio-processor.js` — AudioWorklet Processor（Float32→Int16 PCM変換）
- `public/style.css` — 最小限のスタイル
- `eslint.config.js` — `public/` をブラウザ環境として設定

## Test plan
- [x] `npm run build` パス
- [x] `npm run lint` パス
- [x] `npm run test` 全38テスト合格

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)