### PR TITLE
fix: codex-bridge レビュー指摘バグ一括修正 (#32-#36)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -6,6 +6,7 @@ let audioCtx = null;
 let mediaStream = null;
 /** @type {AudioWorkletNode | null} */
 let workletNode = null;
+let waitingForFinal = false;
 
 const btnStart = document.getElementById('btn-start');
 const btnStop = document.getElementById('btn-stop');
@@ -22,7 +23,6 @@ function setStatus(msg) {
 }
 
 function updateTranscript() {
-  // 既存の子要素をすべて除去
   while (transcriptEl.firstChild) {
     transcriptEl.removeChild(transcriptEl.firstChild);
   }
@@ -45,6 +45,34 @@ function showGraphic(base64) {
   graphicEl.src = 'data:image/png;base64,' + base64;
   graphicEl.style.display = 'block';
   graphicPlaceholder.style.display = 'none';
+}
+
+function cleanupAudio() {
+  if (workletNode) {
+    workletNode.disconnect();
+    workletNode = null;
+  }
+  if (audioCtx) {
+    audioCtx.close().catch(() => {});
+    audioCtx = null;
+  }
+  if (mediaStream) {
+    mediaStream.getTracks().forEach((t) => t.stop());
+    mediaStream = null;
+  }
+}
+
+function closeWebSocket() {
+  if (ws) {
+    ws.close();
+    ws = null;
+  }
+}
+
+function resetUI() {
+  btnStart.disabled = false;
+  btnStop.disabled = true;
+  waitingForFinal = false;
 }
 
 function connectWebSocket() {
@@ -75,6 +103,11 @@ function connectWebSocket() {
       case 'graphic_final':
         showGraphic(msg.png);
         setStatus('最終版グラレコ生成完了');
+        // 最終版を受信したら接続を閉じる
+        if (waitingForFinal) {
+          closeWebSocket();
+          resetUI();
+        }
         break;
       case 'status':
         setStatus(msg.message);
@@ -87,8 +120,10 @@ function connectWebSocket() {
   };
 
   ws.onclose = () => {
-    setStatus('切断');
+    setStatus(waitingForFinal ? '切断（最終版生成中に切断されました）' : '切断');
     ws = null;
+    cleanupAudio();
+    resetUI();
   };
 
   ws.onerror = (err) => {
@@ -135,6 +170,7 @@ async function startRecording() {
     }
   } catch (err) {
     console.error('Recording start failed:', err);
+    cleanupAudio();
     setStatus('マイクの使用が許可されていません');
   }
 }
@@ -142,25 +178,13 @@ async function startRecording() {
 async function stopRecording() {
   btnStop.disabled = true;
   setStatus('最終版を生成中...');
+  waitingForFinal = true;
 
   if (ws && ws.readyState === WebSocket.OPEN) {
     ws.send(JSON.stringify({ type: 'session_end' }));
   }
 
-  if (workletNode) {
-    workletNode.disconnect();
-    workletNode = null;
-  }
-  if (audioCtx) {
-    await audioCtx.close();
-    audioCtx = null;
-  }
-  if (mediaStream) {
-    mediaStream.getTracks().forEach((t) => t.stop());
-    mediaStream = null;
-  }
-
-  btnStart.disabled = false;
+  cleanupAudio();
 }
 
 btnStart.addEventListener('click', startRecording);

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ const PORT = Number(process.env.PORT ?? '8080');
 let config: Config;
 let pool: PlaywrightPool;
 let activeSessions = 0;
+const activeClosePromises = new Set<Promise<void>>();
 
 function sendJson(ws: WebSocket, msg: WsServerMessage): void {
   if (ws.readyState === WebSocket.OPEN) {
@@ -31,6 +32,7 @@ async function handleConnection(ws: WebSocket): Promise<void> {
   }
 
   let session: StreamingSession | null = null;
+  let ending = false;
 
   ws.on('message', async (data, isBinary) => {
     // バイナリ = PCM audio chunk
@@ -62,6 +64,17 @@ async function handleConnection(ws: WebSocket): Promise<void> {
       activeSessions++;
       session = new StreamingSession(config, { playwrightPool: pool });
 
+      const closePromise = new Promise<void>((resolve) => {
+        session!.on('close', () => {
+          activeSessions--;
+          session = null;
+          ending = false;
+          resolve();
+        });
+      });
+      activeClosePromises.add(closePromise);
+      closePromise.then(() => activeClosePromises.delete(closePromise));
+
       session.on('transcript_partial', (text) =>
         sendJson(ws, { type: 'transcript_partial', text }),
       );
@@ -80,10 +93,6 @@ async function handleConnection(ws: WebSocket): Promise<void> {
       session.on('error', (err) =>
         sendJson(ws, { type: 'error', message: err.message }),
       );
-      session.on('close', () => {
-        activeSessions--;
-        session = null;
-      });
 
       try {
         await session.start();
@@ -96,16 +105,18 @@ async function handleConnection(ws: WebSocket): Promise<void> {
         session = null;
       }
     } else if (msg.type === 'session_end') {
-      if (!session) {
+      if (!session || ending) {
         sendJson(ws, { type: 'error', message: 'セッションが開始されていません' });
         return;
       }
+      ending = true;
       await session.end();
     }
   });
 
   ws.on('close', async () => {
-    if (session) {
+    if (session && !ending) {
+      ending = true;
       try {
         await session.end();
       } catch {
@@ -144,6 +155,8 @@ async function main(): Promise<void> {
     console.log('Shutting down...');
     wss.close();
     server.close();
+    // 既存セッションの終了を待つ
+    await Promise.all([...activeClosePromises]);
     await pool.destroy();
     process.exit(0);
   };

--- a/src/streaming/playwright-pool.ts
+++ b/src/streaming/playwright-pool.ts
@@ -22,7 +22,13 @@ export class PlaywrightPool {
 
   async init(): Promise<void> {
     this.browser = await this.launchBrowser();
-    await this.preparePage();
+    try {
+      await this.preparePage();
+    } catch (err) {
+      await this.browser.close().catch(() => {});
+      this.browser = null;
+      throw err;
+    }
   }
 
   async exportToPng(

--- a/src/streaming/session.ts
+++ b/src/streaming/session.ts
@@ -53,6 +53,7 @@ export class StreamingSession extends EventEmitter<SessionEvents> {
   private lastStructuredLength = 0;
   private structuring = false;
   private pendingRetrigger = false;
+  private interimPromise: Promise<void> | null = null;
 
   constructor(config: Config, deps?: SessionDeps) {
     super();
@@ -91,6 +92,11 @@ export class StreamingSession extends EventEmitter<SessionEvents> {
     this.emit('status', '最終版を生成中...');
     this.transcribeStream.close();
 
+    // 進行中の interim 構造化が完了するのを待つ
+    if (this.interimPromise) {
+      await this.interimPromise;
+    }
+
     if (!this.accumulatedText) {
       this.emit('close');
       return;
@@ -125,11 +131,12 @@ export class StreamingSession extends EventEmitter<SessionEvents> {
       return;
     }
 
-    this.triggerInterimUpdate();
+    this.interimPromise = this.triggerInterimUpdate();
   }
 
   private async triggerInterimUpdate(): Promise<void> {
     this.structuring = true;
+    const prevLength = this.lastStructuredLength;
     this.lastStructuredLength = this.accumulatedText.length;
 
     try {
@@ -139,6 +146,8 @@ export class StreamingSession extends EventEmitter<SessionEvents> {
       const png = await this.playwrightPool.exportToPng(doc);
       this.emit('graphic_update', png);
     } catch (err) {
+      // 失敗時はロールバックして再試行可能にする
+      this.lastStructuredLength = prevLength;
       this.emit(
         'error',
         err instanceof Error ? err : new Error(String(err)),
@@ -166,7 +175,7 @@ export class StreamingSession extends EventEmitter<SessionEvents> {
     const { ConverseCommand } = await import(
       '@aws-sdk/client-bedrock-runtime'
     );
-    const { getStructuredContentJsonSchema } = await import(
+    const { getInterimStructuredContentJsonSchema } = await import(
       '../types/structured-content.js'
     );
 
@@ -190,7 +199,7 @@ export class StreamingSession extends EventEmitter<SessionEvents> {
               name: 'structured_output',
               description: '講演の構造化データを出力する（途中版）',
               inputSchema: {
-                json: getStructuredContentJsonSchema() as any,
+                json: getInterimStructuredContentJsonSchema() as any,
               },
             },
           },

--- a/src/streaming/transcribe-stream.ts
+++ b/src/streaming/transcribe-stream.ts
@@ -78,6 +78,8 @@ export class TranscribeStream extends EventEmitter<TranscribeStreamEvents> {
   ): Promise<void> {
     if (!stream) {
       this.emit('error', new Error('TranscriptResultStream is undefined'));
+      this.stopSilenceTimer();
+      this.emit('close');
       return;
     }
 
@@ -127,6 +129,7 @@ export class TranscribeStream extends EventEmitter<TranscribeStreamEvents> {
     } catch (err) {
       this.emit('error', err instanceof Error ? err : new Error(String(err)));
     } finally {
+      this.stopSilenceTimer();
       this.emit('close');
     }
   }

--- a/src/types/structured-content.ts
+++ b/src/types/structured-content.ts
@@ -83,6 +83,74 @@ export const interimStructuredContentSchema = z.object({
 
 export type InterimStructuredContent = z.infer<typeof interimStructuredContentSchema>;
 
+export function getInterimStructuredContentJsonSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    required: ['title', 'mainMessage', 'blocks', 'speechBubbles', 'actions'],
+    properties: {
+      title: { type: 'string', minLength: 1, maxLength: 30 },
+      mainMessage: { type: 'string', minLength: 1, maxLength: 80 },
+      blocks: {
+        type: 'array',
+        minItems: 1,
+        maxItems: 4,
+        items: {
+          type: 'object',
+          required: ['heading', 'bullets'],
+          properties: {
+            heading: { type: 'string', minLength: 1, maxLength: 50 },
+            bullets: {
+              type: 'array',
+              minItems: 1,
+              maxItems: 3,
+              items: {
+                type: 'object',
+                required: ['text'],
+                properties: {
+                  text: { type: 'string', minLength: 1, maxLength: 50 },
+                },
+                additionalProperties: false,
+              },
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      speechBubbles: {
+        type: 'array',
+        minItems: 0,
+        maxItems: 4,
+        items: {
+          type: 'object',
+          required: ['quote'],
+          properties: {
+            quote: { type: 'string', minLength: 1, maxLength: 50 },
+            emphasis: {
+              type: 'string',
+              enum: ['important', 'surprising', 'humorous', 'inspiring'],
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      actions: {
+        type: 'array',
+        minItems: 0,
+        maxItems: 3,
+        items: {
+          type: 'object',
+          required: ['text'],
+          properties: {
+            text: { type: 'string', minLength: 1, maxLength: 50 },
+          },
+          additionalProperties: false,
+        },
+      },
+    },
+    additionalProperties: false,
+  };
+}
+
 export function getStructuredContentJsonSchema(): Record<string, unknown> {
   return {
     type: 'object',


### PR DESCRIPTION
## Summary
codex-bridge の PR レビューで検出された高優先度バグを一括修正。

### #32 TranscribeStream タイマーリーク
- `consumeResultStream()` の finally で `stopSilenceTimer()` を呼ぶ
- `TranscriptResultStream` undefined 時に `close` emit + タイマー停止

### #33 PlaywrightPool init 失敗時ブラウザリーク
- `init()` で `preparePage()` 失敗時に `browser.close()` を呼ぶ

### #34 StreamingSession end() busy 競合
- `end()` で進行中の `interimPromise` 完了を待つ
- `lastStructuredLength` を失敗時にロールバック
- `getInterimStructuredContentJsonSchema()` を新設して interim 用スキーマを使用

### #35 Server activeSessions 負値
- `ending` フラグで `session_end` と `ws close` の二重 end() 防止
- Graceful shutdown で既存セッション完了を待つ

### #36 Web UI リソースリーク
- `cleanupAudio()` を共通化
- `ws.onclose` でマイク・AudioContext を停止
- `graphic_final` 受信後に `ws.close()` を呼ぶ
- `startRecording()` エラー時のリソースクリーンアップ

## Test plan
- [x] `npm run build` パス
- [x] `npm run lint` パス
- [x] `npm run test` 全42テスト合格

Closes #32, Closes #33, Closes #34, Closes #35, Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)