### PR TITLE
Release: ゾーン画像合成パイプライン + 動的レイアウト

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write .",
     "start": "node dist/src/index.js",
     "prepare": "playwright install chromium",
-    "serve": "node dist/src/server.js"
+    "serve": "node dist/src/server.js",
+    "compare-models": "npx tsx scripts/compare-models.ts"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/compare-models.ts
+++ b/scripts/compare-models.ts
@@ -1,0 +1,117 @@
+/**
+ * SD 3.5 Large vs Nova Canvas 比較スクリプト
+ *
+ * Usage:
+ *   npx tsx scripts/compare-models.ts
+ *
+ * 環境変数:
+ *   BEDROCK_IMAGE_REGION (default: us-east-1)
+ *
+ * 出力:
+ *   /tmp/talkcapital-nova-canvas.png
+ *   /tmp/talkcapital-sd35-large.png
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { config as loadDotEnv } from 'dotenv';
+import { generateBackgroundImage, type ImageGenOptions } from '../src/services/illustration.js';
+
+loadDotEnv();
+
+const novaRegion = process.env.BEDROCK_IMAGE_REGION ?? 'us-east-1';
+const sdRegion = process.env.BEDROCK_SD_REGION ?? 'us-west-2';
+
+// サンプルのトピック（sample-structured.json ベース）
+const topics = {
+  title: 'チームの心理的安全性',
+  blockHeadings: ['心理的安全性とは', 'リーダーの役割', '実践のポイント'],
+};
+
+function buildBackgroundPrompt(t: typeof topics): string {
+  // Nova Canvas のプロンプト上限は 1024 文字
+  return [
+    'Professional graphic recording on white paper.',
+    `Topic: ${t.title}. Themes: ${t.blockHeadings.join(', ')}.`,
+    'Layout: title banner top-left, 3-4 content zones in 2x2 grid with colored borders, speech bubbles on right, checklist bottom-right.',
+    'Style: hand-drawn markers, colorful borders (blue green purple red), doodle icons (stick figures lightbulbs stars arrows), numbered circles, curved arrows, masking tape corners, warm cheerful whiteboard aesthetic.',
+    'NO text, words, letters, numbers. Only visual elements: borders, icons, arrows, decorations. Leave blank spaces for text overlay.',
+  ].join(' ');
+}
+
+interface ModelConfig {
+  name: string;
+  modelId: string;
+  region: string;
+  opts: ImageGenOptions;
+}
+
+const models: ModelConfig[] = [
+  {
+    name: 'Nova Canvas',
+    modelId: 'amazon.nova-canvas-v1:0',
+    region: novaRegion,
+    // Nova Canvas の上限は 4.1M pixels。16:9 で最大は 2560x1440 = 3.7M pixels
+    opts: { width: 2560, height: 1440 },
+  },
+  {
+    name: 'SD 3.5 Large',
+    modelId: 'stability.sd3-5-large-v1:0',
+    region: sdRegion,
+    opts: { aspectRatio: '16:9' },
+  },
+];
+
+async function runModel(model: ModelConfig, prompt: string): Promise<{ name: string; elapsed: number; outputPath: string }> {
+  const slug = model.name.toLowerCase().replace(/\s+/g, '-').replace(/\./g, '');
+  const outputPath = `/tmp/talkcapital-${slug}.png`;
+
+  console.log(`\n--- ${model.name} (${model.modelId}) ---`);
+  console.log(`Region: ${model.region}`);
+  console.log('Generating...');
+
+  const start = Date.now();
+  const base64 = await generateBackgroundImage(prompt, model.modelId, model.region, model.opts);
+  const elapsed = Date.now() - start;
+
+  const buf = Buffer.from(base64, 'base64');
+  await writeFile(outputPath, buf);
+
+  console.log(`Done in ${(elapsed / 1000).toFixed(1)}s`);
+  console.log(`Output: ${outputPath} (${(buf.length / 1024).toFixed(0)} KB)`);
+
+  return { name: model.name, elapsed, outputPath };
+}
+
+async function main() {
+  const prompt = buildBackgroundPrompt(topics);
+
+  console.log('=== TalkCapital: AI Image Model Comparison ===');
+  console.log(`Prompt (${prompt.length} chars):\n${prompt}\n`);
+
+  const results: Array<{ name: string; elapsed: number; outputPath: string; error?: string }> = [];
+
+  for (const model of models) {
+    try {
+      const result = await runModel(model, prompt);
+      results.push(result);
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error(`ERROR: ${model.name} failed: ${errMsg}`);
+      results.push({ name: model.name, elapsed: 0, outputPath: '', error: errMsg });
+    }
+  }
+
+  console.log('\n=== Results Summary ===');
+  for (const r of results) {
+    if (r.error) {
+      console.log(`  ${r.name}: FAILED - ${r.error}`);
+    } else {
+      console.log(`  ${r.name}: ${(r.elapsed / 1000).toFixed(1)}s → ${r.outputPath}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/tune-nova.ts
+++ b/scripts/tune-nova.ts
@@ -1,0 +1,108 @@
+/**
+ * Nova Canvas プロンプトチューニング用スクリプト
+ *
+ * 使い方:
+ *   npx tsx scripts/tune-nova.ts              # Claude でプロンプト生成 → Nova Canvas で画像生成
+ *   npx tsx scripts/tune-nova.ts --tag v8     # タグ付きで出力
+ *   npx tsx scripts/tune-nova.ts --no-open    # プレビューを開かない
+ *   npx tsx scripts/tune-nova.ts --prompt-only # プロンプト生成のみ（画像生成しない）
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { join } from 'node:path';
+import { config as loadDotEnv } from 'dotenv';
+import { buildImagePrompt } from '../src/services/prompt-builder.js';
+import { generateBackgroundImage } from '../src/services/illustration.js';
+import type { Config } from '../src/config/index.js';
+import type { StructuredContent } from '../src/types/structured-content.js';
+
+loadDotEnv();
+
+const CONFIG = {
+  width: 2560,
+  height: 1440,
+  quality: 'standard' as 'standard' | 'premium',
+  seed: 42,
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tagIdx = args.indexOf('--tag');
+  const tag = tagIdx >= 0 ? args[tagIdx + 1] : `${Date.now()}`;
+  const noOpen = args.includes('--no-open');
+  const promptOnly = args.includes('--prompt-only');
+
+  // 1. サンプルデータ読み込み
+  const fixturePath = join(import.meta.dirname, '..', 'test', 'fixtures', 'sample-structured.json');
+  const content: StructuredContent = JSON.parse(await readFile(fixturePath, 'utf8'));
+
+  console.log('=== Step 1: StructuredContent ===');
+  console.log(`Title: ${content.title}`);
+  console.log(`Blocks: ${content.blocks.map(b => b.heading).join(', ')}`);
+
+  // 2. Claude でプロンプト生成
+  console.log('\n=== Step 2: Claude でプロンプト生成 ===');
+  const config: Config = {
+    aws: { region: 'ap-northeast-1', s3Bucket: 'dummy', s3KeyPrefix: 'dummy' },
+    llm: { provider: 'bedrock' },
+    bedrock: {
+      modelId: process.env.BEDROCK_MODEL_ID ?? 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
+      region: process.env.BEDROCK_REGION ?? 'us-east-1',
+    },
+    output: { scale: 2 },
+    illustration: { enabled: true, modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
+  };
+  const startPrompt = Date.now();
+  const { prompt, negativePrompt } = await buildImagePrompt(content, config);
+  const promptElapsed = Date.now() - startPrompt;
+
+  console.log(`Done in ${(promptElapsed / 1000).toFixed(1)}s`);
+  console.log(`\nPROMPT (${prompt.length} chars):\n${prompt}\n`);
+  console.log(`NEGATIVE (${negativePrompt.length} chars):\n${negativePrompt}\n`);
+
+  if (promptOnly) {
+    return;
+  }
+
+  // 3. Nova Canvas で画像生成
+  const outputPath = `/tmp/talkcapital-tune-${tag}.png`;
+  const region = process.env.BEDROCK_IMAGE_REGION ?? 'us-east-1';
+
+  console.log('=== Step 3: Nova Canvas で画像生成 ===');
+  console.log(`Config: ${CONFIG.width}x${CONFIG.height}, quality=${CONFIG.quality}, seed=${CONFIG.seed}`);
+  console.log(`Output: ${outputPath}`);
+  console.log('Generating...');
+
+  const startImage = Date.now();
+  const base64 = await generateBackgroundImage(
+    prompt,
+    'amazon.nova-canvas-v1:0',
+    region,
+    {
+      width: CONFIG.width,
+      height: CONFIG.height,
+      negativeText: negativePrompt,
+      quality: CONFIG.quality,
+      seed: CONFIG.seed,
+    },
+  );
+  const imageElapsed = Date.now() - startImage;
+
+  const buf = Buffer.from(base64, 'base64');
+  await writeFile(outputPath, buf);
+
+  console.log(`Done in ${(imageElapsed / 1000).toFixed(1)}s (${(buf.length / 1024).toFixed(0)} KB)`);
+  console.log(`\nTotal: prompt ${(promptElapsed / 1000).toFixed(1)}s + image ${(imageElapsed / 1000).toFixed(1)}s = ${((promptElapsed + imageElapsed) / 1000).toFixed(1)}s`);
+
+  if (!noOpen) {
+    execFile('open', [outputPath], (err) => {
+      if (err) console.error('Failed to open preview:', err.message);
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/tune-sd35.ts
+++ b/scripts/tune-sd35.ts
@@ -1,0 +1,102 @@
+/**
+ * SD 3.5 Large プロンプトチューニング用スクリプト
+ *
+ * 使い方:
+ *   npx tsx scripts/tune-sd35.ts              # Claude でプロンプト生成 → SD 3.5 Large で画像生成
+ *   npx tsx scripts/tune-sd35.ts --tag v1     # タグ付きで出力
+ *   npx tsx scripts/tune-sd35.ts --no-open    # プレビューを開かない
+ *   npx tsx scripts/tune-sd35.ts --prompt-only # プロンプト生成のみ（画像生成しない）
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { join } from 'node:path';
+import { config as loadDotEnv } from 'dotenv';
+import { buildImagePrompt } from '../src/services/prompt-builder.js';
+import { generateBackgroundImage } from '../src/services/illustration.js';
+import type { Config } from '../src/config/index.js';
+import type { StructuredContent } from '../src/types/structured-content.js';
+
+loadDotEnv();
+
+const MODEL_ID = 'stability.sd3-5-large-v1:0';
+const REGION = process.env.BEDROCK_SD_REGION ?? 'us-west-2';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tagIdx = args.indexOf('--tag');
+  const tag = tagIdx >= 0 ? args[tagIdx + 1] : `${Date.now()}`;
+  const noOpen = args.includes('--no-open');
+  const promptOnly = args.includes('--prompt-only');
+
+  // 1. サンプルデータ読み込み
+  const fixturePath = join(import.meta.dirname, '..', 'test', 'fixtures', 'sample-structured.json');
+  const content: StructuredContent = JSON.parse(await readFile(fixturePath, 'utf8'));
+
+  console.log('=== Step 1: StructuredContent ===');
+  console.log(`Title: ${content.title}`);
+  console.log(`Blocks: ${content.blocks.map(b => b.heading).join(', ')}`);
+
+  // 2. Claude でプロンプト生成（SD 3.5 Large 向け）
+  console.log('\n=== Step 2: Claude でプロンプト生成 (SD 3.5 Large 向け) ===');
+  const config: Config = {
+    aws: { region: 'ap-northeast-1', s3Bucket: 'dummy', s3KeyPrefix: 'dummy' },
+    llm: { provider: 'bedrock' },
+    bedrock: {
+      modelId: process.env.BEDROCK_MODEL_ID ?? 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
+      region: process.env.BEDROCK_REGION ?? 'us-east-1',
+    },
+    output: { scale: 2 },
+    illustration: { enabled: true, modelId: MODEL_ID, region: REGION, iconSize: 512 },
+  };
+  const startPrompt = Date.now();
+  const { prompt, negativePrompt } = await buildImagePrompt(content, config, {}, 'sd35-large');
+  const promptElapsed = Date.now() - startPrompt;
+
+  console.log(`Done in ${(promptElapsed / 1000).toFixed(1)}s`);
+  console.log(`\nPROMPT (${prompt.length} chars):\n${prompt}\n`);
+  console.log(`NEGATIVE (${negativePrompt.length} chars):\n${negativePrompt}\n`);
+
+  if (promptOnly) {
+    return;
+  }
+
+  // 3. SD 3.5 Large で画像生成
+  const outputPath = `/tmp/talkcapital-sd35-${tag}.png`;
+
+  console.log(`=== Step 3: SD 3.5 Large で画像生成 ===`);
+  console.log(`Model: ${MODEL_ID}`);
+  console.log(`Region: ${REGION}`);
+  console.log(`Aspect: 16:9 (max ~1344x756)`);
+  console.log(`Output: ${outputPath}`);
+  console.log('Generating...');
+
+  const startImage = Date.now();
+  const base64 = await generateBackgroundImage(
+    prompt,
+    MODEL_ID,
+    REGION,
+    {
+      aspectRatio: '16:9',
+      negativeText: negativePrompt,
+    },
+  );
+  const imageElapsed = Date.now() - startImage;
+
+  const buf = Buffer.from(base64, 'base64');
+  await writeFile(outputPath, buf);
+
+  console.log(`Done in ${(imageElapsed / 1000).toFixed(1)}s (${(buf.length / 1024).toFixed(0)} KB)`);
+  console.log(`\nTotal: prompt ${(promptElapsed / 1000).toFixed(1)}s + image ${(imageElapsed / 1000).toFixed(1)}s = ${((promptElapsed + imageElapsed) / 1000).toFixed(1)}s`);
+
+  if (!noOpen) {
+    execFile('open', [outputPath], (err) => {
+      if (err) console.error('Failed to open preview:', err.message);
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/tune-zones.ts
+++ b/scripts/tune-zones.ts
@@ -1,0 +1,147 @@
+/**
+ * ゾーン画像合成チューニング用スクリプト
+ *
+ * 使い方:
+ *   npx tsx scripts/tune-zones.ts                    # 全ブロック、Nova Canvas
+ *   npx tsx scripts/tune-zones.ts --model sd35       # SD 3.5 Large
+ *   npx tsx scripts/tune-zones.ts --block 0          # ブロック0のみ
+ *   npx tsx scripts/tune-zones.ts --prompt-only      # プロンプト確認のみ
+ *   npx tsx scripts/tune-zones.ts --tag v1           # タグ付き出力
+ *   npx tsx scripts/tune-zones.ts --no-open          # プレビューを開かない
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { join } from 'node:path';
+import { config as loadDotEnv } from 'dotenv';
+import { buildBlockImagePrompts, type ImageModelTarget } from '../src/services/prompt-builder.js';
+import { generateZoneImages } from '../src/services/illustration.js';
+import { renderToHtml } from '../src/services/html-renderer.js';
+import { exportToPng } from '../src/services/exporter.js';
+import type { Config } from '../src/config/index.js';
+import type { StructuredContent } from '../src/types/structured-content.js';
+
+loadDotEnv();
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tagIdx = args.indexOf('--tag');
+  const tag = tagIdx >= 0 ? args[tagIdx + 1] : `${Date.now()}`;
+  const noOpen = args.includes('--no-open');
+  const promptOnly = args.includes('--prompt-only');
+  const layoutOnly = args.includes('--layout-only');
+  const blockIdx = args.indexOf('--block');
+  const blockOnly = blockIdx >= 0 ? Number(args[blockIdx + 1]) : undefined;
+  const modelArg = args.indexOf('--model');
+  const useSD35 = modelArg >= 0 && args[modelArg + 1] === 'sd35';
+  const targetModel: ImageModelTarget = useSD35 ? 'sd35-large' : 'nova-canvas';
+
+  // モデル設定
+  const imageModelId = useSD35 ? 'stability.sd3-5-large-v1:0' : 'amazon.nova-canvas-v1:0';
+  const imageRegion = useSD35
+    ? (process.env.BEDROCK_SD_REGION ?? 'us-west-2')
+    : (process.env.BEDROCK_IMAGE_REGION ?? 'us-east-1');
+
+  // 1. サンプルデータ読み込み
+  const fixtureIdx = args.indexOf('--fixture');
+  const fixturePath = fixtureIdx >= 0
+    ? args[fixtureIdx + 1]
+    : join(import.meta.dirname, '..', 'test', 'fixtures', 'sample-structured.json');
+  const content: StructuredContent = JSON.parse(await readFile(fixturePath, 'utf8'));
+
+  console.log('=== Step 1: StructuredContent ===');
+  console.log(`Title: ${content.title}`);
+  console.log(`Blocks: ${content.blocks.map(b => b.heading).join(', ')}`);
+  console.log(`Model: ${imageModelId} (${imageRegion})`);
+
+  const config: Config = {
+    aws: { region: 'ap-northeast-1', s3Bucket: 'dummy', s3KeyPrefix: 'dummy' },
+    llm: { provider: 'bedrock' },
+    bedrock: {
+      modelId: process.env.BEDROCK_MODEL_ID ?? 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
+      region: process.env.BEDROCK_REGION ?? 'us-east-1',
+    },
+    output: { scale: 2 },
+    illustration: { enabled: true, mode: 'zones', modelId: imageModelId, region: imageRegion, iconSize: 512 },
+  };
+
+  // --layout-only: AWS呼び出しなしでレイアウトのみ確認
+  if (layoutOnly) {
+    console.log('\n=== Layout-only モード（AI画像なし） ===');
+    const html = renderToHtml(content);
+    const outputPath = `/tmp/talkcapital-layout-${tag}.png`;
+    await exportToPng(html, outputPath, 2);
+    console.log(`Output: ${outputPath}`);
+    if (!noOpen) {
+      execFile('open', [outputPath], (err) => {
+        if (err) console.error('Failed to open preview:', err.message);
+      });
+    }
+    return;
+  }
+
+  // 2. Claude でブロック別プロンプト生成
+  console.log(`\n=== Step 2: Claude でブロック別プロンプト生成 (${targetModel}) ===`);
+
+  const startPrompt = Date.now();
+  let blockPrompts = await buildBlockImagePrompts(content, config, {}, targetModel);
+  const promptElapsed = Date.now() - startPrompt;
+
+  console.log(`Done in ${(promptElapsed / 1000).toFixed(1)}s`);
+  for (const bp of blockPrompts) {
+    console.log(`\n--- Block ${bp.blockIndex}: ${content.blocks[bp.blockIndex]?.heading ?? '?'} ---`);
+    console.log(`PROMPT (${bp.prompt.length} chars):\n${bp.prompt}`);
+    console.log(`NEGATIVE: ${bp.negativePrompt}`);
+  }
+
+  if (promptOnly) {
+    return;
+  }
+
+  // 特定ブロックのみ生成
+  if (blockOnly !== undefined) {
+    blockPrompts = blockPrompts.filter(bp => bp.blockIndex === blockOnly);
+    console.log(`\n=== --block ${blockOnly} のみ生成 ===`);
+  }
+
+  // 3. ゾーン画像生成
+  console.log('\n=== Step 3: ゾーン画像生成 ===');
+  const startImage = Date.now();
+  const zoneImages = await generateZoneImages(blockPrompts, config);
+  const imageElapsed = Date.now() - startImage;
+
+  console.log(`Done in ${(imageElapsed / 1000).toFixed(1)}s (${zoneImages.size} images)`);
+
+  // 個別ゾーン画像を保存
+  for (const [idx, dataURL] of zoneImages) {
+    const base64 = dataURL.replace(/^data:image\/png;base64,/, '');
+    const zonePath = `/tmp/talkcapital-zone-${tag}-block${idx}.png`;
+    await writeFile(zonePath, Buffer.from(base64, 'base64'));
+    console.log(`  Block ${idx}: ${zonePath}`);
+  }
+
+  // 4. 合成画像生成
+  console.log('\n=== Step 4: 合成画像生成 ===');
+  const html = renderToHtml(content, { zoneImages });
+  const outputPath = `/tmp/talkcapital-zones-${tag}.png`;
+  await exportToPng(html, outputPath, 2);
+
+  console.log(`Output: ${outputPath}`);
+  console.log(`\nTotal: prompt ${(promptElapsed / 1000).toFixed(1)}s + image ${(imageElapsed / 1000).toFixed(1)}s = ${((promptElapsed + imageElapsed) / 1000).toFixed(1)}s`);
+
+  if (!noOpen) {
+    // 合成画像 + 個別ゾーン画像を開く
+    const filesToOpen = [outputPath];
+    for (const [idx] of zoneImages) {
+      filesToOpen.push(`/tmp/talkcapital-zone-${tag}-block${idx}.png`);
+    }
+    execFile('open', filesToOpen, (err) => {
+      if (err) console.error('Failed to open preview:', err.message);
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -28,6 +28,7 @@ export interface Config {
   };
   illustration: {
     enabled: boolean;
+    mode: 'icons' | 'zones';
     modelId: string;
     region: string;
     iconSize: number;
@@ -94,6 +95,7 @@ export function loadConfig(): Config {
     },
     illustration: {
       enabled: process.env.ILLUSTRATION_ENABLED !== 'false',
+      mode: (process.env.ILLUSTRATION_MODE ?? 'icons') as 'icons' | 'zones',
       modelId: process.env.BEDROCK_IMAGE_MODEL_ID ?? 'amazon.nova-canvas-v1:0',
       region: process.env.BEDROCK_IMAGE_REGION ?? 'us-east-1',
       iconSize: Number(process.env.ILLUSTRATION_ICON_SIZE ?? '100'),

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -5,7 +5,8 @@ import { transcribeAudio } from '../services/transcription.js';
 import { structureTranscript } from '../services/structuring.js';
 import { renderToHtml } from '../services/html-renderer.js';
 import { exportToPng } from '../services/exporter.js';
-import { generateBlockIcons } from '../services/illustration.js';
+import { generateBlockIcons, generateZoneImages } from '../services/illustration.js';
+import { buildBlockImagePrompts } from '../services/prompt-builder.js';
 import type { StructuredContent } from '../types/structured-content.js';
 
 export interface PipelineOptions {
@@ -48,20 +49,29 @@ export async function runPipeline(options: PipelineOptions, config: Config): Pro
   const structured = await structureTranscript(transcript, config);
   timings.structuring = Date.now() - structureStarted;
 
-  // アイコン生成（有効時のみ）
+  // イラスト生成（有効時のみ）
   let illustrations: Map<number, string> | undefined;
+  let zoneImages: Map<number, string> | undefined;
   if (config.illustration.enabled) {
-    logStage('[3/5] アイコン生成中...');
-    const illustrationStarted = Date.now();
-    illustrations = await generateBlockIcons(structured, config);
-    timings.illustration = Date.now() - illustrationStarted;
+    if (config.illustration.mode === 'zones') {
+      logStage('[3/5] ゾーン画像生成中...');
+      const illustrationStarted = Date.now();
+      const blockPrompts = await buildBlockImagePrompts(structured, config);
+      zoneImages = await generateZoneImages(blockPrompts, config);
+      timings.illustration = Date.now() - illustrationStarted;
+    } else {
+      logStage('[3/5] アイコン生成中...');
+      const illustrationStarted = Date.now();
+      illustrations = await generateBlockIcons(structured, config);
+      timings.illustration = Date.now() - illustrationStarted;
+    }
   } else {
-    logStage('[3/5] アイコン生成スキップ');
+    logStage('[3/5] イラスト生成スキップ');
   }
 
   logStage('[4/5] HTML描画中...');
   const templateStarted = Date.now();
-  const html = renderToHtml(structured, { illustrations });
+  const html = renderToHtml(structured, { illustrations, zoneImages });
   timings.template = Date.now() - templateStarted;
 
   const outputFormat = options.outputFormat ?? 'png';

--- a/src/services/html-renderer.ts
+++ b/src/services/html-renderer.ts
@@ -1,10 +1,11 @@
 import type { StructuredContent } from '../types/structured-content.js';
-import { CANVAS, LAYOUT } from '../templates/layout.js';
+import { CANVAS, computeLayout } from '../templates/layout.js';
 import { COLORS } from '../templates/colors.js';
 import { resolveBlockLayouts, seededRandom } from '../templates/layout-presets.js';
 
 export interface RenderOptions {
   illustrations?: Map<number, string>;
+  zoneImages?: Map<number, string>;
   scale?: number;
 }
 
@@ -29,7 +30,11 @@ export function renderToHtml(
   options?: RenderOptions,
 ): string {
   const illustrations = options?.illustrations;
-  const resolvedBlocks = resolveBlockLayouts(content, LAYOUT.blocks);
+  const zoneImages = options?.zoneImages;
+
+  // 動的レイアウト計算
+  const layout = computeLayout(content.blocks.length, content.speechBubbles.length);
+  const resolvedBlocks = resolveBlockLayouts(content, layout.blocks);
 
   const hashStr = content.title + content.mainMessage;
   let hashVal = 0;
@@ -42,42 +47,44 @@ export function renderToHtml(
   const roughCommands: string[] = [];
 
   // ========== Title: Banner/Ribbon shape ==========
-  const tx = LAYOUT.title.x;
-  const ty = LAYOUT.title.y;
-  const tw = LAYOUT.title.width;
-  const th = LAYOUT.title.height;
+  const tx = layout.title.x;
+  const ty = layout.title.y;
+  const tw = layout.title.width;
+  const th = layout.title.height;
   const foldW = 40;
   const bannerPath = `M ${tx + foldW} ${ty} L ${tx + tw - foldW} ${ty} L ${tx + tw} ${ty + th / 2} L ${tx + tw - foldW} ${ty + th} L ${tx + foldW} ${ty + th} L ${tx} ${ty + th / 2} Z`;
   roughCommands.push(`rc.path('${bannerPath}', {fill:'${COLORS.title.bannerFill}', stroke:'${COLORS.title.bannerStroke}', fillStyle:'hachure', hachureGap:14, fillWeight:1.5, roughness:3, strokeWidth:6, bowing:2, seed:${seed()}})`);
 
   // ========== Main message: hachure + underline ==========
-  roughCommands.push(`rc.rectangle(${LAYOUT.mainMessage.x}, ${LAYOUT.mainMessage.y}, ${LAYOUT.mainMessage.width}, ${LAYOUT.mainMessage.height}, {fill:'${COLORS.mainMessage.accentLight}', stroke:'${COLORS.mainMessage.stroke}', fillStyle:'hachure', hachureGap:20, fillWeight:1, roughness:3.5, strokeWidth:5, bowing:1.5, seed:${seed()}})`);
-  const mmUlY = LAYOUT.mainMessage.y + LAYOUT.mainMessage.height - 15;
-  roughCommands.push(`rc.line(${LAYOUT.mainMessage.x + 30}, ${mmUlY}, ${LAYOUT.mainMessage.x + LAYOUT.mainMessage.width - 30}, ${mmUlY}, {stroke:'${COLORS.mainMessage.stroke}', roughness:3, strokeWidth:5, seed:${seed()}})`);
+  roughCommands.push(`rc.rectangle(${layout.mainMessage.x}, ${layout.mainMessage.y}, ${layout.mainMessage.width}, ${layout.mainMessage.height}, {fill:'${COLORS.mainMessage.accentLight}', stroke:'${COLORS.mainMessage.stroke}', fillStyle:'hachure', hachureGap:20, fillWeight:1, roughness:3.5, strokeWidth:5, bowing:1.5, seed:${seed()}})`);
+  const mmUlY = layout.mainMessage.y + layout.mainMessage.height - 15;
+  roughCommands.push(`rc.line(${layout.mainMessage.x + 30}, ${mmUlY}, ${layout.mainMessage.x + layout.mainMessage.width - 30}, ${mmUlY}, {stroke:'${COLORS.mainMessage.stroke}', roughness:3, strokeWidth:5, seed:${seed()}})`);
 
   // ========== Blocks: multi-layer rendering ==========
   for (let i = 0; i < resolvedBlocks.length; i++) {
-    const layout = resolvedBlocks[i];
+    const blk = resolvedBlocks[i];
     const color = COLORS.blocks[i];
 
-    // Layer 1: Light hachure fill (the "paper" background)
-    roughCommands.push(`rc.rectangle(${layout.x}, ${layout.y}, ${layout.width}, ${layout.height}, {fill:'${color.hachure}', stroke:'none', fillStyle:'hachure', hachureGap:24, fillWeight:1, roughness:2, strokeWidth:0, seed:${seed()}})`);
+    // Layer 1: Light hachure fill (skip when zone image is provided)
+    if (!zoneImages?.has(i)) {
+      roughCommands.push(`rc.rectangle(${blk.x}, ${blk.y}, ${blk.width}, ${blk.height}, {fill:'${color.hachure}', stroke:'none', fillStyle:'hachure', hachureGap:24, fillWeight:1, roughness:2, strokeWidth:0, seed:${seed()}})`);
+    }
 
     // Layer 2: Thick hand-drawn border
-    roughCommands.push(`rc.rectangle(${layout.x}, ${layout.y}, ${layout.width}, ${layout.height}, {fill:'transparent', stroke:'${color.stroke}', roughness:3.5, strokeWidth:6, bowing:2, seed:${seed()}})`);
+    roughCommands.push(`rc.rectangle(${blk.x}, ${blk.y}, ${blk.width}, ${blk.height}, {fill:'transparent', stroke:'${color.stroke}', roughness:3.5, strokeWidth:6, bowing:2, seed:${seed()}})`);
 
     // Layer 3: Numbered circle
-    const circleX = layout.x + 35;
-    const circleY = layout.y + 35;
-    roughCommands.push(`rc.circle(${circleX}, ${circleY}, 50, {fill:'${color.stroke}', stroke:'${color.stroke}', fillStyle:'solid', roughness:2.5, strokeWidth:3, seed:${seed()}})`);
+    const circleX = blk.x + 35;
+    const circleY = blk.y + 35;
+    roughCommands.push(`rc.circle(${circleX}, ${circleY}, 60, {fill:'${color.stroke}', stroke:'${color.stroke}', fillStyle:'solid', roughness:2.5, strokeWidth:3, seed:${seed()}})`);
 
     // Layer 4: Heading underline (thick)
-    const ulY = layout.y + 85;
-    roughCommands.push(`rc.line(${layout.x + 60}, ${ulY}, ${layout.x + layout.width - 30}, ${ulY}, {stroke:'${color.stroke}', roughness:3, strokeWidth:4, seed:${seed()}})`);
+    const ulY = blk.y + 100;
+    roughCommands.push(`rc.line(${blk.x + 70}, ${ulY}, ${blk.x + blk.width - 30}, ${ulY}, {stroke:'${color.stroke}', roughness:3, strokeWidth:4, seed:${seed()}})`);
 
     // Layer 5: Tape mark at top-right corner
-    const tapeX = layout.x + layout.width - 50;
-    const tapeY = layout.y - 10;
+    const tapeX = blk.x + blk.width - 50;
+    const tapeY = blk.y - 10;
     const tapeW = 60;
     const tapeH = 25;
     const tapeAngle = (rand() - 0.5) * 0.4 + 0.15;
@@ -94,42 +101,42 @@ export function renderToHtml(
     // Layer 6: Star for high-importance blocks
     const block = content.blocks[i];
     if (block?.importance === 'high') {
-      const starX = layout.x + layout.width - 60;
-      const starY = layout.y + 60;
+      const starX = blk.x + blk.width - 60;
+      const starY = blk.y + 60;
       const starPts = generateStarPoints(starX, starY, 30, 14, 5);
       roughCommands.push(`rc.polygon([${starPts.map(p => `[${Math.round(p[0])},${Math.round(p[1])}]`).join(',')}], {fill:'${color.stroke}', stroke:'${color.stroke}', fillStyle:'hachure', hachureGap:6, roughness:2, strokeWidth:3, seed:${seed()}})`);
     }
   }
 
-  // ========== Speech bubbles ==========
+  // ========== Speech bubbles (横並び、下部) ==========
   for (let i = 0; i < content.speechBubbles.length; i++) {
-    const layout = LAYOUT.speechBubbles[i];
-    if (!layout) break;
+    const bubbleLayout = layout.speechBubbles[i];
+    if (!bubbleLayout) break;
     const bubble = content.speechBubbles[i];
     const bubbleStroke = bubble.emphasis
       ? COLORS.emphasis[bubble.emphasis]
       : COLORS.speechBubble.stroke;
 
-    roughCommands.push(`rc.ellipse(${layout.x + layout.width / 2}, ${layout.y + layout.height / 2}, ${layout.width}, ${layout.height}, {fill:'${COLORS.speechBubble.fill}', stroke:'${bubbleStroke}', fillStyle:'hachure', hachureGap:25, fillWeight:0.8, roughness:3, strokeWidth:5, bowing:2, seed:${seed()}})`);
+    roughCommands.push(`rc.ellipse(${bubbleLayout.x + bubbleLayout.width / 2}, ${bubbleLayout.y + bubbleLayout.height / 2}, ${bubbleLayout.width}, ${bubbleLayout.height}, {fill:'${COLORS.speechBubble.fill}', stroke:'${bubbleStroke}', fillStyle:'hachure', hachureGap:25, fillWeight:0.8, roughness:3, strokeWidth:5, bowing:2, seed:${seed()}})`);
 
-    // Curved speech tail
-    const tailX = layout.x + layout.width * 0.35;
-    const tailY = layout.y + layout.height - 10;
-    roughCommands.push(`rc.curve([[${tailX}, ${tailY}], [${tailX - 10}, ${tailY + 25}], [${tailX - 30}, ${tailY + 50}]], {stroke:'${bubbleStroke}', roughness:2, strokeWidth:4, seed:${seed()}})`);
-    roughCommands.push(`rc.curve([[${tailX + 35}, ${tailY}], [${tailX + 10}, ${tailY + 30}], [${tailX - 30}, ${tailY + 50}]], {stroke:'${bubbleStroke}', roughness:2, strokeWidth:4, seed:${seed()}})`);
+    // Curved speech tail (上向き — ブロックの方を指す)
+    const tailX = bubbleLayout.x + bubbleLayout.width * 0.45;
+    const tailY = bubbleLayout.y + 10;
+    roughCommands.push(`rc.curve([[${tailX}, ${tailY}], [${tailX - 10}, ${tailY - 25}], [${tailX - 30}, ${tailY - 50}]], {stroke:'${bubbleStroke}', roughness:2, strokeWidth:4, seed:${seed()}})`);
+    roughCommands.push(`rc.curve([[${tailX + 35}, ${tailY}], [${tailX + 10}, ${tailY - 30}], [${tailX - 30}, ${tailY - 50}]], {stroke:'${bubbleStroke}', roughness:2, strokeWidth:4, seed:${seed()}})`);
   }
 
   // ========== Actions area ==========
-  roughCommands.push(`rc.rectangle(${LAYOUT.actions.x}, ${LAYOUT.actions.y}, ${LAYOUT.actions.width}, ${LAYOUT.actions.height}, {fill:'${COLORS.actions.fill}', stroke:'${COLORS.actions.stroke}', fillStyle:'cross-hatch', hachureGap:30, fillWeight:0.8, roughness:3, strokeWidth:5, bowing:1.5, seed:${seed()}})`);
+  roughCommands.push(`rc.rectangle(${layout.actions.x}, ${layout.actions.y}, ${layout.actions.width}, ${layout.actions.height}, {fill:'${COLORS.actions.fill}', stroke:'${COLORS.actions.stroke}', fillStyle:'cross-hatch', hachureGap:30, fillWeight:0.8, roughness:3, strokeWidth:5, bowing:1.5, seed:${seed()}})`);
 
   // Actions heading underline
-  roughCommands.push(`rc.line(${LAYOUT.actions.x + 20}, ${LAYOUT.actions.y + 60}, ${LAYOUT.actions.x + LAYOUT.actions.width - 20}, ${LAYOUT.actions.y + 60}, {stroke:'${COLORS.actions.stroke}', roughness:3, strokeWidth:4, seed:${seed()}})`);
+  roughCommands.push(`rc.line(${layout.actions.x + 20}, ${layout.actions.y + 70}, ${layout.actions.x + layout.actions.width - 20}, ${layout.actions.y + 70}, {stroke:'${COLORS.actions.stroke}', roughness:3, strokeWidth:4, seed:${seed()}})`);
 
-  // ========== Connector: curved arrow ==========
-  const titleEndX = LAYOUT.title.x + LAYOUT.title.width + 10;
-  const titleMidY = LAYOUT.title.y + LAYOUT.title.height / 2;
-  const msgStartX = LAYOUT.mainMessage.x - 10;
-  const msgMidY = LAYOUT.mainMessage.y + LAYOUT.mainMessage.height / 2;
+  // ========== Connector: title → main message ==========
+  const titleEndX = layout.title.x + layout.title.width + 10;
+  const titleMidY = layout.title.y + layout.title.height / 2;
+  const msgStartX = layout.mainMessage.x - 10;
+  const msgMidY = layout.mainMessage.y + layout.mainMessage.height / 2;
   const ctrlX = (titleEndX + msgStartX) / 2;
   const ctrlY = titleMidY - 40;
   roughCommands.push(`rc.curve([[${titleEndX}, ${titleMidY}], [${ctrlX}, ${ctrlY}], [${msgStartX}, ${msgMidY}]], {stroke:'${COLORS.connector}', roughness:2, strokeWidth:4, bowing:2, seed:${seed()}})`);
@@ -138,9 +145,8 @@ export function renderToHtml(
   roughCommands.push(`rc.line(${msgStartX}, ${msgMidY}, ${msgStartX - 25}, ${msgMidY + 18}, {stroke:'${COLORS.connector}', roughness:1.5, strokeWidth:4, seed:${seed()}})`);
 
   // ========== Decorative elements ==========
-  // Small decorative circles in whitespace
   const decorSpots = [
-    { x: LAYOUT.title.x + 80, y: LAYOUT.title.y - 10 },
+    { x: layout.title.x + 80, y: layout.title.y - 10 },
     { x: CANVAS.width - 100, y: 80 },
     { x: CANVAS.width - 150, y: CANVAS.height - 100 },
   ];
@@ -149,24 +155,40 @@ export function renderToHtml(
     roughCommands.push(`rc.circle(${spot.x}, ${spot.y}, ${Math.round(r * 2)}, {fill:'transparent', stroke:'${COLORS.decorationLight}', roughness:3, strokeWidth:2, seed:${seed()}})`);
   }
 
-  // Flow arrows between horizontally adjacent blocks
+  // Flow arrows between blocks (relationship-aware)
   for (let i = 0; i < resolvedBlocks.length - 1; i++) {
+    const relation = content.blocks[i]?.relationToNext ?? 'independent';
+    if (relation === 'independent') continue;
+
     const from = resolvedBlocks[i];
     const to = resolvedBlocks[i + 1];
-    if (Math.abs(from.y - to.y) < 100) {
-      const ax = from.x + from.width + 5;
-      const ay = from.y + from.height / 2;
-      const bx = to.x - 5;
-      const by = to.y + to.height / 2;
-      const mx = (ax + bx) / 2;
-      const my = ay - 20;
-      roughCommands.push(`rc.curve([[${ax},${ay}],[${mx},${my}],[${bx},${by}]], {stroke:'${COLORS.decorationLight}', roughness:2, strokeWidth:2.5, seed:${seed()}})`);
+    const sameRow = Math.abs(from.y - to.y) < 100;
+
+    const ax = sameRow ? from.x + from.width + 5 : from.x + from.width / 2;
+    const ay = sameRow ? from.y + from.height / 2 : from.y + from.height + 5;
+    const bx = sameRow ? to.x - 5 : to.x + to.width / 2;
+    const by = sameRow ? to.y + to.height / 2 : to.y - 5;
+    const mx = (ax + bx) / 2;
+    const my = sameRow ? ay - 25 : (ay + by) / 2;
+
+    if (relation === 'causes' || relation === 'builds-on') {
+      // 太い曲線矢印
+      roughCommands.push(`rc.curve([[${ax},${ay}],[${mx},${my}],[${bx},${by}]], {stroke:'${COLORS.connector}', roughness:2.5, strokeWidth:12, bowing:3, seed:${seed()}})`);
+      const dx = bx - mx;
+      const dy = by - my;
+      const len = Math.sqrt(dx * dx + dy * dy) || 1;
+      const nx = dx / len;
+      const ny = dy / len;
+      // 大きな矢じり
+      roughCommands.push(`rc.line(${bx},${by},${bx - 45 * nx + 28 * ny},${by - 45 * ny - 28 * nx}, {stroke:'${COLORS.connector}', roughness:1.5, strokeWidth:12, seed:${seed()}})`);
+      roughCommands.push(`rc.line(${bx},${by},${bx - 45 * nx - 28 * ny},${by - 45 * ny + 28 * nx}, {stroke:'${COLORS.connector}', roughness:1.5, strokeWidth:12, seed:${seed()}})`);
+    } else if (relation === 'contrasts') {
+      roughCommands.push(`rc.line(${ax},${ay},${bx},${by}, {stroke:'${COLORS.connector}', roughness:2.5, strokeWidth:10, strokeLineDash:[24,18], seed:${seed()}})`);
+    } else if (relation === 'supports') {
+      roughCommands.push(`rc.line(${ax},${ay},${bx},${by}, {stroke:'${COLORS.connector}', roughness:2.5, strokeWidth:8, strokeLineDash:[10,16], seed:${seed()}})`);
+      roughCommands.push(`rc.circle(${mx},${my},24, {fill:'${COLORS.connector}', stroke:'${COLORS.connector}', fillStyle:'solid', roughness:1.5, strokeWidth:2, seed:${seed()}})`);
     }
   }
-
-  // Vertical dashed divider
-  const divX = LAYOUT.blocks[0].x + LAYOUT.blocks[0].width * 2 + 120;
-  roughCommands.push(`rc.line(${divX}, ${LAYOUT.title.y + LAYOUT.title.height + 20}, ${divX}, ${CANVAS.height - 50}, {stroke:'${COLORS.decorationLight}', roughness:2.5, strokeWidth:2.5, seed:${seed()}, strokeLineDash:[25,18]})`);
 
   // ========== HTML output ==========
   return `<!DOCTYPE html>
@@ -196,14 +218,14 @@ body {
 }
 .title-text {
   position: absolute;
-  left: ${LAYOUT.title.x}px;
-  top: ${LAYOUT.title.y}px;
-  width: ${LAYOUT.title.width}px;
-  height: ${LAYOUT.title.height}px;
+  left: ${layout.title.x}px;
+  top: ${layout.title.y}px;
+  width: ${layout.title.width}px;
+  height: ${layout.title.height}px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 56px;
+  font-size: ${layout.title.fontSize}px;
   font-weight: 600;
   text-align: center;
   line-height: 1.15;
@@ -212,25 +234,42 @@ body {
 }
 .main-message-text {
   position: absolute;
-  left: ${LAYOUT.mainMessage.x}px;
-  top: ${LAYOUT.mainMessage.y}px;
-  width: ${LAYOUT.mainMessage.width}px;
-  height: ${LAYOUT.mainMessage.height}px;
+  left: ${layout.mainMessage.x}px;
+  top: ${layout.mainMessage.y}px;
+  width: ${layout.mainMessage.width}px;
+  height: ${layout.mainMessage.height}px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 36px;
+  font-size: ${layout.mainMessage.fontSize}px;
   text-align: center;
   line-height: 1.2;
   padding: 0 30px;
 }
 .block-text {
   position: absolute;
-  padding: ${LAYOUT.blockHeadingTopInset}px ${LAYOUT.blockBulletRightPadding}px ${LAYOUT.blockHeadingTopInset}px ${LAYOUT.blockBulletLeftPadding}px;
+  padding: ${layout.blockHeadingTopInset}px ${layout.blockBulletRightPadding}px ${layout.blockHeadingTopInset}px ${layout.blockBulletLeftPadding}px;
   overflow: hidden;
 }
+.block-zone-bg {
+  position: absolute;
+  background-size: cover;
+  background-position: center;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.block-zone-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 251, 235, 0.7);
+}
+.block-zone-bg .block-text {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
 .block-heading {
-  font-size: ${LAYOUT.blockHeadingFontSize}px;
+  font-size: ${layout.blockHeadingFontSize}px;
   font-weight: 600;
   margin-bottom: 14px;
   line-height: 1.2;
@@ -252,29 +291,29 @@ body {
 .block-bullet-list li {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
-  font-size: ${LAYOUT.blockBulletFontSize}px;
+  gap: 14px;
+  font-size: ${layout.blockBulletFontSize}px;
   line-height: 1.7;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 .bullet-dot {
   display: inline-block;
-  width: 12px;
-  height: 12px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   border: 3px solid;
   background: transparent;
   flex-shrink: 0;
-  margin-top: 14px;
+  margin-top: 18px;
 }
 .block-number {
   position: absolute;
-  width: 50px;
-  height: 50px;
+  width: 60px;
+  height: 60px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 28px;
+  font-size: 38px;
   font-weight: 600;
   color: #fff;
   pointer-events: none;
@@ -285,32 +324,32 @@ body {
   align-items: center;
   justify-content: center;
   text-align: center;
-  font-size: 28px;
+  font-size: ${layout.speechBubbleFontSize}px;
   font-style: italic;
   line-height: 1.3;
-  padding: 30px 40px;
+  padding: 40px 50px;
 }
 .actions-text {
   position: absolute;
-  left: ${LAYOUT.actions.x}px;
-  top: ${LAYOUT.actions.y}px;
-  width: ${LAYOUT.actions.width}px;
-  height: ${LAYOUT.actions.height}px;
-  padding: 16px 30px;
+  left: ${layout.actions.x}px;
+  top: ${layout.actions.y}px;
+  width: ${layout.actions.width}px;
+  height: ${layout.actions.height}px;
+  padding: 20px 30px;
 }
 .actions-header {
-  font-size: ${LAYOUT.actions.headerFontSize}px;
+  font-size: ${layout.actions.headerFontSize}px;
   font-weight: 600;
-  margin-bottom: 16px;
+  margin-bottom: 20px;
   line-height: 1.2;
-  padding-bottom: 8px;
+  padding-bottom: 10px;
 }
 .action-item {
   display: flex;
   align-items: flex-start;
   gap: 14px;
-  margin-bottom: 18px;
-  font-size: ${LAYOUT.actions.itemFontSize}px;
+  margin-bottom: 20px;
+  font-size: ${layout.actions.itemFontSize}px;
   line-height: 1.4;
   padding-left: 50px;
 }
@@ -324,25 +363,38 @@ body {
 <div class="main-message-text">${escapeHtml(content.mainMessage)}</div>
 
 ${content.blocks.map((block, i) => {
-  const layout = resolvedBlocks[i];
+  const blk = resolvedBlocks[i];
   const color = COLORS.blocks[i];
   const illust = illustrations?.get(i);
-  const circleX = layout.x + 35;
-  const circleY = layout.y + 35;
-  return `<div class="block-number" style="left:${circleX - 25}px;top:${circleY - 25}px;">${i + 1}</div>
-<div class="block-text" style="left:${layout.x}px;top:${layout.y}px;width:${layout.width}px;height:${layout.height}px;">
-  <div class="block-heading" style="color:${color.stroke}">${escapeHtml(block.heading)}</div>
+  const zoneImg = zoneImages?.get(i);
+  const circleX = blk.x + 35;
+  const circleY = blk.y + 35;
+  const blockContent = `<div class="block-heading" style="color:${color.stroke}">${escapeHtml(block.heading)}</div>
   ${illust ? `<img class="block-illustration" src="${illust}" alt="">` : ''}
   <ul class="block-bullet-list">
     ${block.bullets.map(b => `<li><span class="bullet-dot" style="border-color:${color.stroke}"></span>${escapeHtml(b.text)}</li>`).join('\n    ')}
-  </ul>
+  </ul>`;
+
+  if (zoneImg) {
+    return `<div class="block-number" style="left:${circleX - 30}px;top:${circleY - 30}px;">${i + 1}</div>
+<div class="block-zone-bg" style="left:${blk.x}px;top:${blk.y}px;width:${blk.width}px;height:${blk.height}px;background-image:url(${zoneImg});">
+  <div class="block-zone-overlay"></div>
+  <div class="block-text">
+    ${blockContent}
+  </div>
+</div>`;
+  }
+
+  return `<div class="block-number" style="left:${circleX - 30}px;top:${circleY - 30}px;">${i + 1}</div>
+<div class="block-text" style="left:${blk.x}px;top:${blk.y}px;width:${blk.width}px;height:${blk.height}px;">
+  ${blockContent}
 </div>`;
 }).join('\n')}
 
 ${content.speechBubbles.map((bubble, i) => {
-  const layout = LAYOUT.speechBubbles[i];
-  if (!layout) return '';
-  return `<div class="bubble-text" style="left:${layout.x}px;top:${layout.y}px;width:${layout.width}px;height:${layout.height}px;">
+  const bubbleLayout = layout.speechBubbles[i];
+  if (!bubbleLayout) return '';
+  return `<div class="bubble-text" style="left:${bubbleLayout.x}px;top:${bubbleLayout.y}px;width:${bubbleLayout.width}px;height:${bubbleLayout.height}px;">
   &ldquo;${escapeHtml(bubble.quote)}&rdquo;
 </div>`;
 }).join('\n')}

--- a/src/services/illustration.ts
+++ b/src/services/illustration.ts
@@ -1,6 +1,7 @@
 import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
 import type { Config } from '../config/index.js';
 import type { StructuredContent } from '../types/structured-content.js';
+import type { BlockImagePromptResult } from './prompt-builder.js';
 
 export interface IllustrationDependencies {
   client?: Pick<BedrockRuntimeClient, 'send'>;
@@ -26,10 +27,56 @@ export async function generateBlockIcons(
     const prompt = buildIconPrompt(block.heading);
 
     try {
-      const imageBase64 = await invokeImageModel(client, config.illustration.modelId, prompt, size);
+      const imageBase64 = await invokeImageModel(client, config.illustration.modelId, prompt, { width: size, height: size });
       return { index, dataURL: `data:image/png;base64,${imageBase64}` };
     } catch (error) {
       process.stderr.write(`[illustration] block ${index} のアイコン生成に失敗: ${String(error)}\n`);
+      return null;
+    }
+  });
+
+  const results = await Promise.all(tasks);
+  const map = new Map<number, string>();
+  for (const result of results) {
+    if (result) {
+      map.set(result.index, result.dataURL);
+    }
+  }
+  return map;
+}
+
+/**
+ * ブロック単位のゾーン画像を生成する。
+ * 各画像は合成時にブロック背景として使用される。
+ * 返り値はブロックインデックス → base64 DataURL のマップ。
+ */
+export async function generateZoneImages(
+  prompts: BlockImagePromptResult[],
+  config: Config,
+  deps: IllustrationDependencies = {},
+): Promise<Map<number, string>> {
+  if (!config.illustration.enabled) {
+    return new Map();
+  }
+
+  const client = deps.client ?? new BedrockRuntimeClient({ region: config.illustration.region });
+  const modelId = config.illustration.modelId;
+
+  // モデルに応じたサイズ設定
+  const isNovaCanvas = modelId.startsWith('amazon.nova-canvas');
+  const opts: ImageGenOptions = isNovaCanvas
+    ? { width: 1280, height: 640, quality: 'standard' }
+    : { aspectRatio: '16:9' };
+
+  const tasks = prompts.map(async (blockPrompt) => {
+    try {
+      const imageBase64 = await invokeImageModel(client, modelId, blockPrompt.prompt, {
+        ...opts,
+        negativeText: blockPrompt.negativePrompt,
+      });
+      return { index: blockPrompt.blockIndex, dataURL: `data:image/png;base64,${imageBase64}` };
+    } catch (error) {
+      process.stderr.write(`[illustration] block ${blockPrompt.blockIndex} のゾーン画像生成に失敗: ${String(error)}\n`);
       return null;
     }
   });
@@ -50,18 +97,50 @@ function buildIconPrompt(heading: string): string {
 
 const NEGATIVE_TEXT = 'text, words, letters, alphabet, numbers, kanji, hiragana, katakana, writing, caption, label, watermark, signature';
 
+export interface ImageGenOptions {
+  /** Nova Canvas 用: 画像の幅 (px, 16の倍数, 320-4096) */
+  width?: number;
+  /** Nova Canvas 用: 画像の高さ (px, 16の倍数, 320-4096) */
+  height?: number;
+  /** SD 3.5 Large 用: アスペクト比 (デフォルト '1:1') */
+  aspectRatio?: '16:9' | '1:1' | '21:9' | '2:3' | '3:2' | '4:5' | '5:4' | '9:16' | '9:21';
+  /** カスタムネガティブプロンプト（省略時はデフォルトを使用） */
+  negativeText?: string;
+  /** Nova Canvas 用: 品質 (デフォルト 'standard') */
+  quality?: 'standard' | 'premium';
+  /** 再現性のためのシード値 (0 = ランダム) */
+  seed?: number;
+}
+
+/**
+ * 背景画像を生成する。
+ * 返り値は base64 エンコードされた PNG データ。
+ */
+export async function generateBackgroundImage(
+  prompt: string,
+  modelId: string,
+  region: string,
+  opts: ImageGenOptions = {},
+  deps: IllustrationDependencies = {},
+): Promise<string> {
+  const client = deps.client ?? new BedrockRuntimeClient({ region });
+  return invokeImageModel(client, modelId, prompt, opts);
+}
+
 async function invokeImageModel(
   client: Pick<BedrockRuntimeClient, 'send'>,
   modelId: string,
   prompt: string,
-  size: number,
+  opts: ImageGenOptions,
 ): Promise<string> {
+  const negText = opts.negativeText ?? NEGATIVE_TEXT;
+
   if (modelId.startsWith('amazon.nova-canvas')) {
-    return invokeNovaCanvas(client, modelId, prompt, size);
+    return invokeNovaCanvas(client, modelId, prompt, negText, opts.width ?? 1024, opts.height ?? 1024, opts.quality ?? 'standard', opts.seed ?? 0);
   }
 
   if (modelId.startsWith('stability.')) {
-    return invokeStabilityModel(client, modelId, prompt, size);
+    return invokeStabilityModel(client, modelId, prompt, negText, opts.aspectRatio ?? '1:1');
   }
 
   throw new Error(`未対応の画像生成モデル: ${modelId}`);
@@ -71,8 +150,22 @@ async function invokeNovaCanvas(
   client: Pick<BedrockRuntimeClient, 'send'>,
   modelId: string,
   prompt: string,
-  size: number,
+  negativeText: string,
+  width: number,
+  height: number,
+  quality: 'standard' | 'premium',
+  seed: number,
 ): Promise<string> {
+  const imageGenConfig: Record<string, unknown> = {
+    width,
+    height,
+    numberOfImages: 1,
+    quality,
+  };
+  if (seed > 0) {
+    imageGenConfig.seed = seed;
+  }
+
   const command = new InvokeModelCommand({
     modelId,
     contentType: 'application/json',
@@ -81,14 +174,9 @@ async function invokeNovaCanvas(
       taskType: 'TEXT_IMAGE',
       textToImageParams: {
         text: prompt,
-        negativeText: NEGATIVE_TEXT,
+        negativeText: negativeText,
       },
-      imageGenerationConfig: {
-        width: size,
-        height: size,
-        numberOfImages: 1,
-        quality: 'standard',
-      },
+      imageGenerationConfig: imageGenConfig,
     }),
   });
 
@@ -107,31 +195,31 @@ async function invokeStabilityModel(
   client: Pick<BedrockRuntimeClient, 'send'>,
   modelId: string,
   prompt: string,
-  size: number,
+  negativeText: string,
+  aspectRatio: string,
 ): Promise<string> {
   const command = new InvokeModelCommand({
     modelId,
     contentType: 'application/json',
     accept: 'application/json',
     body: JSON.stringify({
-      text_prompts: [
-        { text: prompt, weight: 1 },
-        { text: NEGATIVE_TEXT, weight: -1 },
-      ],
-      cfg_scale: 7,
-      steps: 30,
-      width: size,
-      height: size,
+      prompt,
+      negative_prompt: negativeText,
+      aspect_ratio: aspectRatio,
+      output_format: 'png',
     }),
   });
 
   const response = await client.send(command);
   const body = JSON.parse(new TextDecoder().decode(response.body)) as {
-    artifacts?: Array<{ base64: string; finishReason: string }>;
+    images?: string[];
+    seeds?: number[];
+    finish_reasons?: Array<string | null>;
   };
 
-  if (!body.artifacts || body.artifacts.length === 0) {
-    throw new Error('Stability AI からの画像レスポンスが空です');
+  if (!body.images || body.images.length === 0) {
+    const reason = body.finish_reasons?.[0] ?? 'unknown';
+    throw new Error(`Stability AI からの画像レスポンスが空です (reason: ${reason})`);
   }
-  return body.artifacts[0].base64;
+  return body.images[0];
 }

--- a/src/services/prompt-builder.ts
+++ b/src/services/prompt-builder.ts
@@ -1,0 +1,351 @@
+import { BedrockRuntimeClient, ConverseCommand } from '@aws-sdk/client-bedrock-runtime';
+import type { Config } from '../config/index.js';
+import type { StructuredContent } from '../types/structured-content.js';
+
+export interface PromptBuilderDependencies {
+  client?: Pick<BedrockRuntimeClient, 'send'>;
+}
+
+export type ImageModelTarget = 'nova-canvas' | 'sd35-large';
+
+export interface ImagePromptResult {
+  prompt: string;
+  negativePrompt: string;
+}
+
+export interface BlockImagePromptResult {
+  blockIndex: number;
+  prompt: string;
+  negativePrompt: string;
+}
+
+/**
+ * StructuredContent の具体的な内容から、画像生成用プロンプトを構築する。
+ * Claude に各ブロックの内容を読ませ、描くべき具体的なイラスト・アイコンを抽出させる。
+ */
+export async function buildImagePrompt(
+  content: StructuredContent,
+  config: Config,
+  deps: PromptBuilderDependencies = {},
+  targetModel: ImageModelTarget = 'nova-canvas',
+): Promise<ImagePromptResult> {
+  const client = deps.client ?? new BedrockRuntimeClient({ region: config.bedrock.region });
+
+  const contentSummary = formatContentForLLM(content);
+  const systemPrompt = targetModel === 'sd35-large' ? SYSTEM_PROMPT_SD35 : SYSTEM_PROMPT;
+
+  const command = new ConverseCommand({
+    modelId: config.bedrock.modelId,
+    system: [{ text: systemPrompt }],
+    messages: [
+      {
+        role: 'user',
+        content: [{ text: contentSummary }],
+      },
+    ],
+  });
+
+  const response = await client.send(command);
+  const outputText = extractTextResponse(response.output?.message?.content as unknown[]);
+  process.stderr.write(`[prompt-builder] Raw LLM response:\n${outputText}\n`);
+
+  return parsePromptResponse(outputText);
+}
+
+/**
+ * StructuredContent の各ブロックごとに画像生成用プロンプトを構築する。
+ * 1回の LLM 呼び出しで全ブロック分を一括生成し、JSON 配列で返させる。
+ */
+export async function buildBlockImagePrompts(
+  content: StructuredContent,
+  config: Config,
+  deps: PromptBuilderDependencies = {},
+  targetModel: ImageModelTarget = 'nova-canvas',
+): Promise<BlockImagePromptResult[]> {
+  const client = deps.client ?? new BedrockRuntimeClient({ region: config.bedrock.region });
+
+  const userMessage = formatBlocksForLLM(content);
+  const systemPrompt = targetModel === 'sd35-large' ? ZONE_SYSTEM_PROMPT_SD35 : ZONE_SYSTEM_PROMPT_NOVA;
+
+  const command = new ConverseCommand({
+    modelId: config.bedrock.modelId,
+    system: [{ text: systemPrompt }],
+    messages: [
+      {
+        role: 'user',
+        content: [{ text: userMessage }],
+      },
+    ],
+  });
+
+  const response = await client.send(command);
+  const outputText = extractTextResponse(response.output?.message?.content as unknown[]);
+  process.stderr.write(`[prompt-builder] Block prompts raw response:\n${outputText}\n`);
+
+  return parseBlockPromptResponse(outputText, content.blocks.length);
+}
+
+function formatBlocksForLLM(content: StructuredContent): string {
+  const blocks = content.blocks
+    .map((b, i) => {
+      const bullets = b.bullets.map((bl) => `  - ${bl.text}`).join('\n');
+      return `ブロック${i + 1}「${b.heading}」:\n${bullets}`;
+    })
+    .join('\n\n');
+
+  return `以下のグラフィックレコーディングの各ブロックについて、個別にゾーン画像用のプロンプトを生成してください。
+
+講演タイトル: ${content.title}
+メインメッセージ: ${content.mainMessage}
+ブロック数: ${content.blocks.length}
+
+${blocks}`;
+}
+
+function parseBlockPromptResponse(text: string, blockCount: number): BlockImagePromptResult[] {
+  // JSON 配列を抽出（```json ... ``` ブロックまたは直接 JSON）
+  const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/) ?? text.match(/(\[[\s\S]*\])/);
+  if (!jsonMatch) {
+    throw new Error('LLMレスポンスからブロックプロンプトのJSON配列を抽出できません');
+  }
+
+  const parsed = JSON.parse(jsonMatch[1].trim()) as Array<{
+    blockIndex: number;
+    prompt: string;
+    negativePrompt: string;
+  }>;
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error('ブロックプロンプトのJSON配列が空です');
+  }
+
+  return parsed.map((item, i) => ({
+    blockIndex: item.blockIndex ?? i,
+    prompt: item.prompt,
+    negativePrompt: item.negativePrompt ?? DEFAULT_NEGATIVE,
+  }));
+}
+
+function formatContentForLLM(content: StructuredContent): string {
+  const blocks = content.blocks
+    .map((b, i) => {
+      const bullets = b.bullets.map((bl) => `  - ${bl.text}`).join('\n');
+      return `ブロック${i + 1}「${b.heading}」:\n${bullets}`;
+    })
+    .join('\n\n');
+
+  const bubbles = content.speechBubbles.map((b) => `「${b.quote}」`).join('\n');
+
+  const actions = content.actions.map((a) => `- ${a.text}`).join('\n');
+
+  return `以下のグラフィックレコーディングの内容から、描くべきイラストを提案してください。
+
+タイトル: ${content.title}
+メインメッセージ: ${content.mainMessage}
+
+${blocks}
+
+印象的な発言:
+${bubbles}
+
+アクション:
+${actions}`;
+}
+
+function extractTextResponse(content: unknown[]): string {
+  for (const item of content) {
+    const block = item as Record<string, unknown>;
+    if (block.text && typeof block.text === 'string') {
+      return block.text;
+    }
+  }
+  throw new Error('Bedrockレスポンスにテキストが含まれていません');
+}
+
+function parsePromptResponse(text: string): ImagePromptResult {
+  // PROMPT: と NEGATIVE: のセクションを抽出（改行あり/なし両対応）
+  const promptMatch = text.match(/PROMPT:\s*([\s\S]*?)(?=\nNEGATIVE:|$)/);
+  const negativeMatch = text.match(/NEGATIVE:\s*([\s\S]*?)(?=\n\n|$)/);
+
+  if (!promptMatch) {
+    throw new Error('LLMレスポンスからPROMPTセクションを抽出できません');
+  }
+
+  return {
+    prompt: promptMatch[1].trim(),
+    negativePrompt: negativeMatch ? negativeMatch[1].trim() : DEFAULT_NEGATIVE,
+  };
+}
+
+const DEFAULT_NEGATIVE =
+  'text, words, letters, alphabet, numbers, kanji, hiragana, katakana, korean, chinese, writing, handwriting, font, typography, calligraphy, whiteboard frame, whiteboard edge, board border, wall, room, desk, markers, pens, eraser, photograph, 3d object, shadow, perspective, neon, saturated, vivid, rainbow, cluttered, busy';
+
+const SYSTEM_PROMPT_SD35 = `あなたは、グラフィックレコーディング用の画像生成プロンプトを作成するアシスタントです。
+
+# タスク
+講演の構造化データを受け取り、AI画像生成モデル（Stable Diffusion 3.5 Large）に渡す英語プロンプトを生成してください。
+
+# 重要なルール
+1. 講演内容に**実際に登場した具体的なモノ・シーン・人物の動き**をイラストのモチーフにする
+   - 例: 「会議冒頭で安心を宣言」→ a person standing at a meeting table with hand raised, warm smile
+   - 例: 「クラウド移行の課題」→ a cloud with a winding path leading to it, small figures carrying boxes
+2. 抽象的・汎用的なアイコン（電球、歯車など）は、内容と直接関係がある場合のみ使う
+3. **人物はデフォルメされたキャラクター**で描く（棒人間ではなく、丸い頭と簡略化された体を持つキャラクター）
+4. **プロンプトに含めてはいけない表現**（これを破るとテキストが画像に描かれてしまう）:
+   - "symbolizing ○○" "representing ○○" "indicating ○○" "depicting ○○" など意味説明 → 絶対禁止
+   - "speech bubble with text" "thought bubble with words" → テキストが生成される。"empty speech balloon" を使う
+   - 引用符で囲んだ英語テキスト（"Team Safety" など）→ そのまま画像にテキストとして描かれる。絶対禁止
+   - "title" "banner" "label" "header" "caption" → テキスト要素が生成される。"decorated rectangular frame" 等で代替
+   - 抽象概念の英単語（"safety" "communication" "failure" "psychological" "trust" "sharing" など）→ テキストとして描かれる
+   - 代わりに、**身体のポーズと具体的な物体だけ**で表現する
+   - プロンプトの最後に必ず "no text, no words, no letters, no numbers, no writing anywhere" を付ける
+   - **概念名・テーマ名は一切使わない**。"about ○○" "related to ○○" も禁止
+
+# 画像の構造要件
+SD 3.5 Large は高品質な描画が可能なので、以下のリッチなグラレコレイアウトを指示すること：
+
+- **スタイル**: professional graphic recording, hand-drawn illustration on white paper with colored markers and pens
+- **レイアウト**: 画面全体に情報を密に配置
+  - 左上に大きな装飾枠（リボン風バナー、中は空白）
+  - 中央に3〜4個のコンテンツゾーン（手描き風の色付きボーダー: 青、緑、オレンジ、紫。内側は白）
+  - 各ゾーンの近くに関連する**詳細なイラスト**（2〜3要素ずつ）
+  - ゾーン間を曲線の矢印やフローラインで接続
+  - 右側に空の吹き出し2〜3個（中は空白）
+  - 右下に空のチェックボックス枠
+  - 角にマスキングテープ風の装飾
+- **色使い**: warm color palette, hand-drawn marker strokes, bold outlines with thin detail lines
+- **イラスト密度**: 各ゾーンに2〜3個の具体的なイラスト。全体で10〜15個のイラスト要素
+- **装飾**: 小さな星、矢印、番号付き丸、波線アンダーライン、ハイライトマーカー風の色帯
+- テキスト・文字は**絶対に含めない**（テキストは後からオーバーレイする）
+
+# 出力フォーマット
+以下の形式で出力してください。補足説明は一切不要です。PROMPTとNEGATIVEのみ出力してください。
+
+PROMPT:
+（英語の画像生成プロンプト。改行なし1段落）
+
+NEGATIVE:
+（除外する要素。英語カンマ区切り。改行なし1段落）`;
+
+const SYSTEM_PROMPT = `あなたは、グラフィックレコーディング用の画像生成プロンプトを作成するアシスタントです。
+
+# タスク
+講演の構造化データを受け取り、AI画像生成モデル（Amazon Nova Canvas）に渡す英語プロンプトを生成してください。
+
+# 重要なルール
+1. 講演内容に**実際に登場した具体的なモノ・シーン**をイラストのモチーフにする
+   - 例: 「会議冒頭で安心を宣言」→ a small stick figure raising hand at a table
+   - 例: 「クラウド移行の課題」→ a small cloud icon with an arrow
+2. 抽象的・汎用的なアイコン（電球、歯車など）は、内容と直接関係がある場合のみ使う
+3. イラストは各ゾーン枠線の隅に小さく添える程度。人物は棒人間（stick figure）で十分
+4. **プロンプトに含めてはいけない表現**（これを破るとテキストが画像に描かれてしまう）:
+   - "symbolizing ○○" "representing ○○" "indicating ○○" "showing ○○" "depicting ○○" など意味説明 → 絶対禁止
+   - "speech bubble" "thought bubble" → 中にテキストが生成される。"empty oval outline" を使う
+   - 抽象概念の英単語すべて（"communication" "dialogue" "message" "safety" "team" "failure" "question" "psychological" "welcoming" "sharing" "open" など）→ テキストとして描かれる
+   - 代わりに、**身体のポーズと具体的な物体だけ**で表現する（例: "stick figure with arms spread wide", "two stick figures facing each other", "stick figure with one hand up"）
+   - プロンプトの最後に必ず "absolutely no text anywhere in the image" を付ける
+   - **概念名・テーマ名は一切使わない**。"about ○○" "related to ○○" も禁止
+
+# 画像の構造要件（最重要）
+以下の構造を必ずプロンプトに含めること：
+- 白いフラットな背景が画面全体を覆う（ホワイトボードの縁・枠・壁は見えない）
+- **3個の大きな空の長方形**が画面の主要構造（画面の60%以上を占める）
+  - 各長方形は「太いマーカーの枠線だけ」で描かれ、内部は背景と同じ白のまま
+  - 左上: 青い枠線、右上: 緑の枠線、左下: オレンジの枠線
+- 各長方形の**外側**に、関連する小さな棒人間やアイコンを1つだけ配置
+- 右側に2つの空の楕円アウトライン（内部は白）
+- 右下に小さな四角い枠線
+- ゾーン間を曲線の矢印で接続
+- **スタイル**: シンプルなホワイトボードマーカーの線画。太い線、少ない要素、たっぷりの余白
+- 水彩・ペイント・塗りつぶし・グラデーションは使わない
+- テキスト・文字は**絶対に含めない**
+
+# 出力フォーマット
+以下の形式で出力してください。補足説明は一切不要です。PROMPTとNEGATIVEのみ出力してください。
+
+PROMPT:
+（英語の画像生成プロンプト。1024文字以内。改行なし1段落）
+
+NEGATIVE:
+（除外する要素。英語カンマ区切り。改行なし1段落）`;
+
+// ============================================================
+// ゾーン画像用システムプロンプト（ブロック単位の画像生成）
+// ============================================================
+
+const ZONE_COMMON_RULES = `
+# 重要なルール
+1. 講演内容に**実際に登場した具体的なモノ・シーン・人物の動き**をイラストのモチーフにする
+   - 例: 「会議冒頭で安心を宣言」→ a person standing at a table with hand raised
+   - 例: 「クラウド移行の課題」→ a cloud with a winding path, small figures carrying boxes
+2. 抽象的・汎用的なアイコン（電球、歯車など）は、内容と直接関係がある場合のみ使う
+3. **プロンプトに含めてはいけない表現**（テキストが画像に描かれてしまう）:
+   - "symbolizing" "representing" "indicating" "depicting" → 絶対禁止
+   - 引用符で囲んだ英語テキスト（"Team Safety" 等）→ 絶対禁止
+   - "title" "banner" "label" "header" "caption" → 禁止
+   - 抽象概念の英単語（"safety" "communication" "failure" "trust" 等）→ テキストとして描かれる
+   - 代わりに**身体のポーズと具体的な物体だけ**で表現する
+   - 各プロンプトの最後に必ず "no text, no words, no letters, no numbers, no writing anywhere" を付ける
+   - **概念名・テーマ名は一切使わない**
+
+# ゾーン画像の制約（最重要）
+- この画像は大きなグラフィックレコーディングの**1ゾーン**として合成される
+- **中央エリアは後からテキストを重ねるので、比較的シンプルに保つ**
+- イラストは主に**辺縁・隅・端**に配置する
+- 背景は温かみのある淡い色調（純白ではなく、ほんのりクリーム色）
+- 全ゾーンで統一されたスタイル（同じ線の太さ、同じ色調のパレット）
+- ゾーンの端は他のゾーンと接合されるため、端を装飾しすぎない`;
+
+const ZONE_SYSTEM_PROMPT_NOVA = `あなたは、グラフィックレコーディングのゾーン画像用プロンプトを作成するアシスタントです。
+
+# タスク
+講演の各ブロック（トピック）ごとに、Amazon Nova Canvas 用の画像生成プロンプトを1つずつ生成してください。
+各ゾーン画像は最終的に1つの大きなグラレコに合成されます。
+${ZONE_COMMON_RULES}
+
+# Nova Canvas 固有の注意
+- 各プロンプトは**800文字以内**（改行なし1段落）
+- スタイル: soft watercolor illustration, warm pastel tones, hand-drawn feel, gentle marker lines
+- 人物は丸い頭と簡略化された体を持つキャラクター
+- 各ゾーンに2〜3個の具体的なイラスト要素
+
+# 出力フォーマット
+以下のJSON配列を出力してください。補足説明は一切不要です。JSONのみ出力してください。
+
+\`\`\`json
+[
+  {
+    "blockIndex": 0,
+    "prompt": "英語の画像生成プロンプト。改行なし1段落。800文字以内",
+    "negativePrompt": "除外する要素。英語カンマ区切り"
+  },
+  ...
+]
+\`\`\``;
+
+const ZONE_SYSTEM_PROMPT_SD35 = `あなたは、グラフィックレコーディングのゾーン画像用プロンプトを作成するアシスタントです。
+
+# タスク
+講演の各ブロック（トピック）ごとに、Stable Diffusion 3.5 Large 用の画像生成プロンプトを1つずつ生成してください。
+各ゾーン画像は最終的に1つの大きなグラレコに合成されます。
+${ZONE_COMMON_RULES}
+
+# SD 3.5 Large 固有の注意
+- スタイル: professional graphic recording, hand-drawn illustration with colored markers on white paper
+- 人物はデフォルメされたキャラクター（丸い頭、簡略化された体）
+- 各ゾーンに3〜4個の具体的でリッチなイラスト要素
+- 色使い: warm color palette, bold outlines with thin detail lines
+
+# 出力フォーマット
+以下のJSON配列を出力してください。補足説明は一切不要です。JSONのみ出力してください。
+
+\`\`\`json
+[
+  {
+    "blockIndex": 0,
+    "prompt": "英語の画像生成プロンプト。改行なし1段落",
+    "negativePrompt": "除外する要素。英語カンマ区切り"
+  },
+  ...
+]
+\`\`\``;

--- a/src/services/structuring.ts
+++ b/src/services/structuring.ts
@@ -172,4 +172,10 @@ const SYSTEM_PROMPT = `あなたは講演の内容をグラフィックレコー
 7. actionsは必ず3個（「今日からできる」具体的アクション）
 8. 専門用語は講演で使われていた表現をそのまま使用
 9. 情報を詰め込みすぎない。余白を意識し、重要度の高い内容のみ抽出
-10. 各blockにimportanceを付与する。講演で最も強調・時間を割いていたテーマを"high"、補足的なテーマを"low"、その他を"medium"とする。highは最大1個`;
+10. 各blockにimportanceを付与する。講演で最も強調・時間を割いていたテーマを"high"、補足的なテーマを"low"、その他を"medium"とする。highは最大1個
+11. 各blockにrelationToNextを付与する（最後のblockは除く）。次のブロックとの関係性:
+    - "causes": このトピックが次の原因・前提
+    - "contrasts": 次と対比的
+    - "supports": 次を補強
+    - "builds-on": 次がこのトピックの発展
+    - "independent": 特に関係なし`;

--- a/src/streaming/session.ts
+++ b/src/streaming/session.ts
@@ -4,7 +4,8 @@ import { TranscribeStream } from './transcribe-stream.js';
 import { PlaywrightPool } from './playwright-pool.js';
 import { structureTranscript, type StructuringDependencies } from '../services/structuring.js';
 import { renderToHtml } from '../services/html-renderer.js';
-import { generateBlockIcons, type IllustrationDependencies } from '../services/illustration.js';
+import { generateBlockIcons, generateZoneImages, type IllustrationDependencies } from '../services/illustration.js';
+import { buildBlockImagePrompts } from '../services/prompt-builder.js';
 import {
   interimStructuredContentSchema,
   structuredContentSchema,
@@ -116,15 +117,21 @@ export class StreamingSession extends EventEmitter<SessionEvents> {
 
       // 最終版でのみイラスト生成
       let illustrations: Map<number, string> | undefined;
+      let zoneImages: Map<number, string> | undefined;
       if (this.config.illustration.enabled) {
-        illustrations = await generateBlockIcons(
-          structured,
-          this.config,
-          this.illustrationDeps,
-        );
+        if (this.config.illustration.mode === 'zones') {
+          const blockPrompts = await buildBlockImagePrompts(structured, this.config);
+          zoneImages = await generateZoneImages(blockPrompts, this.config, this.illustrationDeps);
+        } else {
+          illustrations = await generateBlockIcons(
+            structured,
+            this.config,
+            this.illustrationDeps,
+          );
+        }
       }
 
-      const html = renderToHtml(structured, { illustrations });
+      const html = renderToHtml(structured, { illustrations, zoneImages });
       const png = await this.playwrightPool.renderHtmlToPng(html);
       this.emit('graphic_final', png);
     } catch (err) {

--- a/src/templates/layout-presets.ts
+++ b/src/templates/layout-presets.ts
@@ -53,8 +53,8 @@ export function resolveBlockLayouts(
     const block = content.blocks[i];
     const importance = block?.importance ?? 'medium';
 
-    // 重要度によるサイズスケール
-    const scale = importance === 'high' ? 1.12 : importance === 'low' ? 0.92 : 1.0;
+    // 重要度によるサイズスケール（ギャップ40pxに収まるよう控えめに）
+    const scale = importance === 'high' ? 1.02 : importance === 'low' ? 0.98 : 1.0;
     const width = Math.round(base.width * scale);
     const height = Math.round(base.height * scale);
 
@@ -62,10 +62,10 @@ export function resolveBlockLayouts(
     const dx = Math.round((base.width - width) / 2);
     const dy = Math.round((base.height - height) / 2);
 
-    // 微小ジッター（±4px位置、±0.015rad≈±0.86度回転）
-    const jitterX = Math.round((rand() - 0.5) * 8);
-    const jitterY = Math.round((rand() - 0.5) * 8);
-    const angle = (rand() - 0.5) * 0.03;
+    // 微小ジッター（±2px位置、±0.008rad≈±0.46度回転）
+    const jitterX = Math.round((rand() - 0.5) * 4);
+    const jitterY = Math.round((rand() - 0.5) * 4);
+    const angle = (rand() - 0.5) * 0.016;
 
     return {
       x: base.x + dx + jitterX,

--- a/src/templates/layout.ts
+++ b/src/templates/layout.ts
@@ -3,94 +3,166 @@ export const CANVAS = {
   height: 2160,
 } as const;
 
-// 全体レイアウト:
-// 上部: タイトル + メインメッセージ (横並び)
-// 中央: 4ブロック (2x2グリッド)
-// 右側: 吹き出し (縦並び) + アクション
+// ========== 動的レイアウト ==========
+// ブロック数・吹き出し数に応じてレイアウトを動的に計算する
 
 const PADDING = 50;
-const GAP = 40;
+const GAP = 110;
 
-// タイトル行
-const TITLE_H = 120;
+export interface DynamicLayout {
+  title: { x: number; y: number; width: number; height: number; fontSize: number };
+  mainMessage: { x: number; y: number; width: number; height: number; fontSize: number };
+  blocks: Array<{ x: number; y: number; width: number; height: number }>;
+  blockHeadingFontSize: number;
+  blockBulletFontSize: number;
+  blockHeadingHeight: number;
+  blockHeadingTopInset: number;
+  blockBulletTopOffset: number;
+  blockBulletLineHeight: number;
+  blockBulletLeftPadding: number;
+  blockBulletRightPadding: number;
+  speechBubbles: Array<{ x: number; y: number; width: number; height: number }>;
+  speechBubbleFontSize: number;
+  actions: { x: number; y: number; width: number; height: number; headerFontSize: number; itemFontSize: number };
+}
 
-// ブロックエリア (左側 ~63%)
-const BLOCKS_AREA_W = 2400;
-const BLOCK_W = (BLOCKS_AREA_W - GAP) / 2; // ~1180
-const BLOCK_H = 600;
+export function computeLayout(blockCount: number, bubbleCount: number): DynamicLayout {
+  const contentW = CANVAS.width - PADDING * 2; // 3740
 
-// 吹き出しエリア (右側)
-const BUBBLE_AREA_X = PADDING + BLOCKS_AREA_W + 80;
-const BUBBLE_W = 3840 - BUBBLE_AREA_X - PADDING;
-const BUBBLE_H = 200;
-const BUBBLE_GAP = 40;
+  // タイトル行
+  const TITLE_H = 140;
+  const TITLE_W = 1400;
 
-export const LAYOUT = {
-  title: {
-    x: PADDING,
-    y: PADDING,
-    width: 1200,
-    height: TITLE_H,
-    fontSize: 52,
-    textAlign: 'center' as const,
-  },
-  mainMessage: {
-    x: PADDING + 1200 + GAP,
-    y: PADDING,
-    width: 3840 - PADDING * 2 - 1200 - GAP,
-    height: TITLE_H,
-    fontSize: 36,
-    textAlign: 'center' as const,
-  },
-  blocks: [
-    {
-      x: PADDING,
-      y: PADDING + TITLE_H + GAP,
-      width: BLOCK_W,
-      height: BLOCK_H,
+  // ブロックグリッド計算
+  const blockRows = blockCount <= 2 ? 1 : 2;
+  const blockH = blockRows === 1 ? 780 : 580;
+  const blocksH = blockH * blockRows + GAP * (blockRows - 1);
+
+  // 下部エリア（吹き出し + アクション）
+  const BOTTOM_H = 350;
+
+  // 全体を垂直方向にセンタリング
+  const totalContentH = TITLE_H + GAP + blocksH + GAP + BOTTOM_H;
+  const topOffset = Math.max(PADDING, Math.floor((CANVAS.height - totalContentH) / 2));
+
+  const titleY = topOffset;
+  const blockStartY = topOffset + TITLE_H + GAP;
+  const bottomY = blockStartY + blocksH + GAP;
+
+  // ブロック座標
+  const blocks = computeBlockPositions(blockCount, PADDING, blockStartY, contentW, blockH, GAP);
+
+  // 吹き出し: 下部左側に横並び（~63%幅）
+  const bubbleAreaW = Math.floor(contentW * 0.63);
+  const effectiveBubbleCount = Math.min(bubbleCount, 4);
+  const bubbleW = effectiveBubbleCount > 0
+    ? Math.floor((bubbleAreaW - GAP * (effectiveBubbleCount - 1)) / effectiveBubbleCount)
+    : 0;
+
+  const speechBubbles: Array<{ x: number; y: number; width: number; height: number }> = [];
+  for (let i = 0; i < effectiveBubbleCount; i++) {
+    speechBubbles.push({
+      x: PADDING + i * (bubbleW + GAP),
+      y: bottomY,
+      width: bubbleW,
+      height: BOTTOM_H,
+    });
+  }
+
+  // アクション: 下部右側（~35%幅）
+  const actionsX = PADDING + bubbleAreaW + GAP;
+  const actionsW = contentW - bubbleAreaW - GAP;
+
+  return {
+    title: { x: PADDING, y: titleY, width: TITLE_W, height: TITLE_H, fontSize: 76 },
+    mainMessage: {
+      x: PADDING + TITLE_W + GAP,
+      y: titleY,
+      width: CANVAS.width - PADDING * 2 - TITLE_W - GAP,
+      height: TITLE_H,
+      fontSize: 48,
     },
-    {
-      x: PADDING + BLOCK_W + GAP,
-      y: PADDING + TITLE_H + GAP,
-      width: BLOCK_W,
-      height: BLOCK_H,
+    blocks,
+    blockHeadingFontSize: 54,
+    blockBulletFontSize: 36,
+    blockHeadingHeight: 90,
+    blockHeadingTopInset: 30,
+    blockBulletTopOffset: 120,
+    blockBulletLineHeight: 100,
+    blockBulletLeftPadding: 80,
+    blockBulletRightPadding: 40,
+    speechBubbles,
+    speechBubbleFontSize: 36,
+    actions: {
+      x: actionsX,
+      y: bottomY,
+      width: actionsW,
+      height: BOTTOM_H,
+      headerFontSize: 48,
+      itemFontSize: 36,
     },
-    {
-      x: PADDING,
-      y: PADDING + TITLE_H + GAP + BLOCK_H + GAP,
-      width: BLOCK_W,
-      height: BLOCK_H,
-    },
-    {
-      x: PADDING + BLOCK_W + GAP,
-      y: PADDING + TITLE_H + GAP + BLOCK_H + GAP,
-      width: BLOCK_W,
-      height: BLOCK_H,
-    },
-  ],
-  /** ブロック内のフォントサイズ */
-  blockHeadingFontSize: 40,
-  blockBulletFontSize: 26,
-  /** ブロック内部のレイアウト定数 */
-  blockHeadingHeight: 70,
-  blockHeadingTopInset: 25,
-  blockBulletTopOffset: 100,
-  blockBulletLineHeight: 80,
-  blockBulletLeftPadding: 70,
-  blockBulletRightPadding: 36,
-  speechBubbles: [
-    { x: BUBBLE_AREA_X, y: PADDING + TITLE_H + GAP, width: BUBBLE_W, height: BUBBLE_H },
-    { x: BUBBLE_AREA_X, y: PADDING + TITLE_H + GAP + (BUBBLE_H + BUBBLE_GAP), width: BUBBLE_W, height: BUBBLE_H },
-    { x: BUBBLE_AREA_X, y: PADDING + TITLE_H + GAP + (BUBBLE_H + BUBBLE_GAP) * 2, width: BUBBLE_W, height: BUBBLE_H },
-    { x: BUBBLE_AREA_X, y: PADDING + TITLE_H + GAP + (BUBBLE_H + BUBBLE_GAP) * 3, width: BUBBLE_W, height: BUBBLE_H },
-  ],
-  speechBubbleFontSize: 26,
-  actions: {
-    x: BUBBLE_AREA_X,
-    y: PADDING + TITLE_H + GAP + (BUBBLE_H + BUBBLE_GAP) * 4 + 30,
-    width: BUBBLE_W,
-    height: 500,
-    headerFontSize: 36,
-    itemFontSize: 28,
-  },
-} as const;
+  };
+}
+
+function computeBlockPositions(
+  blockCount: number,
+  padding: number,
+  startY: number,
+  contentW: number,
+  blockH: number,
+  gap: number,
+): Array<{ x: number; y: number; width: number; height: number }> {
+  const blocks: Array<{ x: number; y: number; width: number; height: number }> = [];
+
+  if (blockCount === 1) {
+    // 1 ブロック: 全幅
+    blocks.push({ x: padding, y: startY, width: contentW, height: blockH });
+  } else if (blockCount === 2) {
+    // 2 ブロック: 横並び
+    const w = Math.floor((contentW - gap) / 2);
+    blocks.push({ x: padding, y: startY, width: w, height: blockH });
+    blocks.push({ x: padding + w + gap, y: startY, width: w, height: blockH });
+  } else if (blockCount === 3) {
+    // 3 ブロック: 上段2 + 下段1（中央寄せ）
+    const w2 = Math.floor((contentW - gap) / 2);
+    blocks.push({ x: padding, y: startY, width: w2, height: blockH });
+    blocks.push({ x: padding + w2 + gap, y: startY, width: w2, height: blockH });
+    const row2Y = startY + blockH + gap;
+    const centerX = padding + Math.floor((contentW - w2) / 2);
+    blocks.push({ x: centerX, y: row2Y, width: w2, height: blockH });
+  } else if (blockCount === 4) {
+    // 4 ブロック: 2×2
+    const w2 = Math.floor((contentW - gap) / 2);
+    blocks.push({ x: padding, y: startY, width: w2, height: blockH });
+    blocks.push({ x: padding + w2 + gap, y: startY, width: w2, height: blockH });
+    const row2Y = startY + blockH + gap;
+    blocks.push({ x: padding, y: row2Y, width: w2, height: blockH });
+    blocks.push({ x: padding + w2 + gap, y: row2Y, width: w2, height: blockH });
+  } else {
+    // 5+ ブロック: 上段3 + 下段2（残り）
+    const w3 = Math.floor((contentW - gap * 2) / 3);
+    const topCount = Math.min(3, blockCount);
+    for (let i = 0; i < topCount; i++) {
+      blocks.push({ x: padding + i * (w3 + gap), y: startY, width: w3, height: blockH });
+    }
+    const bottomCount = blockCount - topCount;
+    if (bottomCount > 0) {
+      const row2Y = startY + blockH + gap;
+      const w2 = Math.floor((contentW - gap) / 2);
+      if (bottomCount === 1) {
+        const centerX = padding + Math.floor((contentW - w2) / 2);
+        blocks.push({ x: centerX, y: row2Y, width: w2, height: blockH });
+      } else {
+        for (let i = 0; i < Math.min(bottomCount, 3); i++) {
+          blocks.push({ x: padding + i * (w2 + gap), y: row2Y, width: w2, height: blockH });
+        }
+      }
+    }
+  }
+
+  return blocks;
+}
+
+// ========== 後方互換 ==========
+// 既存コード（テスト等）が LAYOUT を直接参照している場合の互換エクスポート
+export const LAYOUT = computeLayout(4, 4);

--- a/src/types/structured-content.ts
+++ b/src/types/structured-content.ts
@@ -19,6 +19,7 @@ export const structuredContentSchema = z.object({
           .min(1)
           .max(3),
         importance: z.enum(['high', 'medium', 'low']).optional(),
+        relationToNext: z.enum(['causes', 'contrasts', 'supports', 'builds-on', 'independent']).optional(),
       }),
     )
     .min(3)
@@ -60,6 +61,7 @@ export const interimStructuredContentSchema = z.object({
           .min(1)
           .max(3),
         importance: z.enum(['high', 'medium', 'low']).optional(),
+        relationToNext: z.enum(['causes', 'contrasts', 'supports', 'builds-on', 'independent']).optional(),
       }),
     )
     .min(1)
@@ -117,6 +119,10 @@ export function getInterimStructuredContentJsonSchema(): Record<string, unknown>
             importance: {
               type: 'string',
               enum: ['high', 'medium', 'low'],
+            },
+            relationToNext: {
+              type: 'string',
+              enum: ['causes', 'contrasts', 'supports', 'builds-on', 'independent'],
             },
           },
           additionalProperties: false,
@@ -189,6 +195,10 @@ export function getStructuredContentJsonSchema(): Record<string, unknown> {
             importance: {
               type: 'string',
               enum: ['high', 'medium', 'low'],
+            },
+            relationToNext: {
+              type: 'string',
+              enum: ['causes', 'contrasts', 'supports', 'builds-on', 'independent'],
             },
           },
           additionalProperties: false,

--- a/test/fixtures/sample-structured.json
+++ b/test/fixtures/sample-structured.json
@@ -8,7 +8,9 @@
         { "text": "対人リスクを取れる環境" },
         { "text": "発言しやすさが成果を左右" },
         { "text": "沈黙は危険信号" }
-      ]
+      ],
+      "importance": "high",
+      "relationToNext": "causes"
     },
     {
       "heading": "リーダーの役割",
@@ -16,7 +18,9 @@
         { "text": "失敗を先に共有する" },
         { "text": "質問を歓迎する" },
         { "text": "感謝を言葉で伝える" }
-      ]
+      ],
+      "importance": "medium",
+      "relationToNext": "builds-on"
     },
     {
       "heading": "実践のポイント",

--- a/test/pipeline/orchestrator.test.ts
+++ b/test/pipeline/orchestrator.test.ts
@@ -28,7 +28,7 @@ const config = {
   llm: { provider: 'bedrock' as const },
   bedrock: { region: 'us-east-1', modelId: 'model' },
   output: { scale: 2 },
-  illustration: { enabled: false, modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
+  illustration: { enabled: false, mode: 'icons' as const, modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
 };
 
 describe('orchestrator', () => {
@@ -103,7 +103,7 @@ describe('orchestrator', () => {
 
     expect(stdoutSpy).toHaveBeenCalledWith('[1/5] 文字起こしスキップ: 既存ファイルを読み込み\n');
     expect(stdoutSpy).toHaveBeenCalledWith('[2/5] Bedrock 構造化中...\n');
-    expect(stdoutSpy).toHaveBeenCalledWith('[3/5] アイコン生成スキップ\n');
+    expect(stdoutSpy).toHaveBeenCalledWith('[3/5] イラスト生成スキップ\n');
     expect(stdoutSpy).toHaveBeenCalledWith('[4/5] HTML描画中...\n');
     expect(stdoutSpy).toHaveBeenCalledWith('[5/5] PNG エクスポート 中...\n');
   });

--- a/test/services/illustration.test.ts
+++ b/test/services/illustration.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test, vi } from 'vitest';
+import { generateBlockIcons, generateBackgroundImage } from '../../src/services/illustration.js';
+import type { Config } from '../../src/config/index.js';
+import type { StructuredContent } from '../../src/types/structured-content.js';
+
+function makeMockClient(responseBody: unknown) {
+  return {
+    send: vi.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify(responseBody)),
+    }),
+  };
+}
+
+const sampleContent: StructuredContent = {
+  title: 'テスト',
+  mainMessage: 'テストメッセージ',
+  blocks: [
+    { heading: 'ブロック1', bullets: [{ text: '箇条書き1' }] },
+    { heading: 'ブロック2', bullets: [{ text: '箇条書き2' }] },
+    { heading: 'ブロック3', bullets: [{ text: '箇条書き3' }] },
+  ],
+  speechBubbles: [{ quote: '引用', emphasis: 'important' }],
+  actions: [{ text: 'アクション1' }, { text: 'アクション2' }, { text: 'アクション3' }],
+};
+
+function makeConfig(modelId: string): Config {
+  return {
+    aws: { region: 'ap-northeast-1', s3Bucket: 'test', s3KeyPrefix: 'test' },
+    llm: { provider: 'bedrock' },
+    bedrock: { modelId: 'anthropic.claude-sonnet-4-20250514-v1:0', region: 'us-east-1' },
+    output: { scale: 2 },
+    illustration: { enabled: true, mode: 'icons' as const, modelId, region: 'us-east-1', iconSize: 512 },
+  };
+}
+
+describe('illustration', () => {
+  describe('Nova Canvas', () => {
+    test('generateBlockIcons で画像が生成される', async () => {
+      const client = makeMockClient({ images: ['base64data'] });
+      const config = makeConfig('amazon.nova-canvas-v1:0');
+      const result = await generateBlockIcons(sampleContent, config, { client });
+
+      expect(result.size).toBe(3);
+      expect(result.get(0)).toBe('data:image/png;base64,base64data');
+
+      const sentBody = JSON.parse(client.send.mock.calls[0][0].input.body);
+      expect(sentBody.taskType).toBe('TEXT_IMAGE');
+      expect(sentBody.textToImageParams.text).toContain('ブロック1');
+      expect(sentBody.textToImageParams.negativeText).toBeTruthy();
+      expect(sentBody.imageGenerationConfig.width).toBe(512);
+      expect(sentBody.imageGenerationConfig.height).toBe(512);
+    });
+
+    test('generateBackgroundImage で 3840x2160 画像が生成される', async () => {
+      const client = makeMockClient({ images: ['bg-base64'] });
+      const result = await generateBackgroundImage(
+        'test prompt',
+        'amazon.nova-canvas-v1:0',
+        'us-east-1',
+        { width: 3840, height: 2160 },
+        { client },
+      );
+
+      expect(result).toBe('bg-base64');
+      const sentBody = JSON.parse(client.send.mock.calls[0][0].input.body);
+      expect(sentBody.imageGenerationConfig.width).toBe(3840);
+      expect(sentBody.imageGenerationConfig.height).toBe(2160);
+    });
+
+    test('画像レスポンスが空の場合エラー', async () => {
+      const client = makeMockClient({ images: [] });
+      const config = makeConfig('amazon.nova-canvas-v1:0');
+
+      await expect(
+        generateBlockIcons(sampleContent, config, { client }),
+      ).resolves.toEqual(new Map());
+      // エラーは stderr に出力されるが、generateBlockIcons は null を返して Map に含めない
+    });
+  });
+
+  describe('SD 3.5 Large', () => {
+    test('generateBlockIcons で画像が生成される', async () => {
+      const client = makeMockClient({ images: ['sd-base64'], seeds: [12345], finish_reasons: [null] });
+      const config = makeConfig('stability.sd3-5-large-v1:0');
+      const result = await generateBlockIcons(sampleContent, config, { client });
+
+      expect(result.size).toBe(3);
+      expect(result.get(0)).toBe('data:image/png;base64,sd-base64');
+
+      const sentBody = JSON.parse(client.send.mock.calls[0][0].input.body);
+      expect(sentBody.prompt).toContain('ブロック1');
+      expect(sentBody.negative_prompt).toBeTruthy();
+      expect(sentBody.aspect_ratio).toBe('1:1');
+      expect(sentBody.output_format).toBe('png');
+      // 旧SDXL形式のフィールドがないことを確認
+      expect(sentBody.text_prompts).toBeUndefined();
+      expect(sentBody.cfg_scale).toBeUndefined();
+    });
+
+    test('generateBackgroundImage で 16:9 画像が生成される', async () => {
+      const client = makeMockClient({ images: ['bg-sd-base64'], seeds: [99], finish_reasons: [null] });
+      const result = await generateBackgroundImage(
+        'test prompt',
+        'stability.sd3-5-large-v1:0',
+        'us-east-1',
+        { aspectRatio: '16:9' },
+        { client },
+      );
+
+      expect(result).toBe('bg-sd-base64');
+      const sentBody = JSON.parse(client.send.mock.calls[0][0].input.body);
+      expect(sentBody.aspect_ratio).toBe('16:9');
+    });
+
+    test('フィルターでブロックされた場合エラー', async () => {
+      const client = makeMockClient({ finish_reasons: ['Filter reason: prompt'] });
+
+      await expect(
+        generateBackgroundImage('bad prompt', 'stability.sd3-5-large-v1:0', 'us-east-1', {}, { client }),
+      ).rejects.toThrow('画像レスポンスが空です');
+    });
+  });
+
+  test('未対応モデルIDでエラー', async () => {
+    const client = makeMockClient({});
+
+    await expect(
+      generateBackgroundImage('test', 'unknown.model-v1:0', 'us-east-1', {}, { client }),
+    ).rejects.toThrow('未対応の画像生成モデル');
+  });
+
+  test('illustration.enabled が false の場合は空の Map を返す', async () => {
+    const config = makeConfig('amazon.nova-canvas-v1:0');
+    config.illustration.enabled = false;
+    const result = await generateBlockIcons(sampleContent, config);
+    expect(result.size).toBe(0);
+  });
+});

--- a/test/services/structuring.test.ts
+++ b/test/services/structuring.test.ts
@@ -7,7 +7,7 @@ const config: Config = {
   llm: { provider: 'bedrock' },
   bedrock: { region: 'us-east-1', modelId: 'model' },
   output: { scale: 2 },
-  illustration: { enabled: false, modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
+  illustration: { enabled: false, mode: 'icons', modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
 };
 
 const openRouterConfig: Config = {
@@ -20,7 +20,7 @@ const openRouterConfig: Config = {
     baseUrl: 'https://openrouter.ai/api/v1',
   },
   output: { scale: 2 },
-  illustration: { enabled: false, modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
+  illustration: { enabled: false, mode: 'icons', modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
 };
 
 describe('structuring service', () => {

--- a/test/services/transcription.test.ts
+++ b/test/services/transcription.test.ts
@@ -10,7 +10,7 @@ const config: Config = {
   llm: { provider: 'bedrock' },
   bedrock: { region: 'us-east-1', modelId: 'model' },
   output: { scale: 2 },
-  illustration: { enabled: false, modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
+  illustration: { enabled: false, mode: 'icons', modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
 };
 
 describe('transcription service', () => {

--- a/test/streaming/integration.test.ts
+++ b/test/streaming/integration.test.ts
@@ -8,7 +8,7 @@ const mockConfig: Config = {
   llm: { provider: 'bedrock' as const },
   bedrock: { modelId: 'anthropic.claude-sonnet-4-20250514-v1:0', region: 'us-east-1' },
   output: { scale: 2 },
-  illustration: { enabled: false, modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
+  illustration: { enabled: false, mode: 'icons', modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
 };
 
 function createMockTranscribeStream() {

--- a/test/streaming/session.test.ts
+++ b/test/streaming/session.test.ts
@@ -8,7 +8,7 @@ const mockConfig: Config = {
   llm: { provider: 'bedrock' as const },
   bedrock: { modelId: 'anthropic.claude-sonnet-4-20250514-v1:0', region: 'us-east-1' },
   output: { scale: 2 },
-  illustration: { enabled: false, modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
+  illustration: { enabled: false, mode: 'icons', modelId: 'amazon.nova-canvas-v1:0', region: 'us-east-1', iconSize: 512 },
 };
 
 function createMockTranscribeStream() {


### PR DESCRIPTION
develop → main リリース。PR #41 の squash merge を含む。

### 主な変更
- ゾーン画像パイプライン（prompt-builder → illustration → html-renderer）
- 動的レイアウト（computeLayout: 1-6ブロック対応）
- フォントサイズ約35%拡大
- relationToNextによるブロック間コネクター
- 61テスト全パス