### PR TITLE
fix(ci): ESLint scriptsパース修正 + 未使用変数削除

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import globals from 'globals';
 
 export default [
   {
-    ignores: ['dist/**', 'node_modules/**', 'export/**', 'vitest.config.ts'],
+    ignores: ['dist/**', 'node_modules/**', 'export/**', 'scripts/**', 'vitest.config.ts'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/src/services/prompt-builder.ts
+++ b/src/services/prompt-builder.ts
@@ -82,7 +82,7 @@ export async function buildBlockImagePrompts(
   const outputText = extractTextResponse(response.output?.message?.content as unknown[]);
   process.stderr.write(`[prompt-builder] Block prompts raw response:\n${outputText}\n`);
 
-  return parseBlockPromptResponse(outputText, content.blocks.length);
+  return parseBlockPromptResponse(outputText);
 }
 
 function formatBlocksForLLM(content: StructuredContent): string {
@@ -102,7 +102,7 @@ function formatBlocksForLLM(content: StructuredContent): string {
 ${blocks}`;
 }
 
-function parseBlockPromptResponse(text: string, blockCount: number): BlockImagePromptResult[] {
+function parseBlockPromptResponse(text: string): BlockImagePromptResult[] {
   // JSON 配列を抽出（```json ... ``` ブロックまたは直接 JSON）
   const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/) ?? text.match(/(\[[\s\S]*\])/);
   if (!jsonMatch) {


### PR DESCRIPTION
## 修正内容

PR #41 マージ後のCI lint失敗を修正。

1. `scripts/*.ts` を ESLint の ignore に追加（`tsconfig.json` の include に含まれていないためパーサーエラー）
2. `prompt-builder.ts:parseBlockPromptResponse` の未使用引数 `blockCount` を削除

### CI失敗ログ
```
scripts/compare-models.ts  0:0  error  Parsing error: file was not found in any of the provided project(s)
scripts/tune-nova.ts       0:0  error  (同上)
scripts/tune-sd35.ts       0:0  error  (同上)
scripts/tune-zones.ts      0:0  error  (同上)
src/services/prompt-builder.ts  105:49  error  blockCount is defined but never used
```